### PR TITLE
feat: Add flex-concurrency tests

### DIFF
--- a/functions/deploy-concurrency-experiments.sh
+++ b/functions/deploy-concurrency-experiments.sh
@@ -1,0 +1,196 @@
+#!/bin/bash
+set -euo pipefail
+
+# Deployment script for both concurrency experiments
+#
+# Creates a Flex Consumption function app and deploys both experiments.
+# Run this once to set up the Azure resources.
+#
+# Optional env vars (defaults reuse existing shared resources):
+#   SUBSCRIPTION_ID    - Azure subscription
+#   RESOURCE_GROUP_NAME - Azure resource group
+#   REGION              - Azure region
+#   STORAGE_ACCOUNT     - required only when app must be created
+#   THROTTLE_FUNC_NAME  - Function app name for throttle experiment
+#   PER_INSTANCE_FUNC_NAME - Function app name for per-instance experiment
+#   REFERENCE_FUNCTION_NAME - Existing app from which to reuse AI connection string
+#   THROTTLE_ALWAYS_READY_HTTP - Always-ready HTTP instances for throttle app
+#   THROTTLE_MAX_INSTANCE_COUNT - Max instances cap for throttle app
+
+SUBSCRIPTION_ID="${SUBSCRIPTION_ID:-0ebbefb8-987e-4fcd-bbbc-41d704f2d586}"
+RESOURCE_GROUP_NAME="${RESOURCE_GROUP_NAME:-playground-kamil}"
+REGION="${REGION:-westeurope}"
+STORAGE_ACCOUNT="${STORAGE_ACCOUNT:-}"
+
+THROTTLE_FUNC_NAME="${THROTTLE_FUNC_NAME:-azfe-concurrency-throttle}"
+PER_INSTANCE_FUNC_NAME="${PER_INSTANCE_FUNC_NAME:-azfe-per-instance-conc}"
+REFERENCE_FUNCTION_NAME="${REFERENCE_FUNCTION_NAME:-azure-test-otel}"
+THROTTLE_ALWAYS_READY_HTTP="${THROTTLE_ALWAYS_READY_HTTP:-2}"
+THROTTLE_MAX_INSTANCE_COUNT="${THROTTLE_MAX_INSTANCE_COUNT:-2}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "=== Deploying Concurrency Experiments ==="
+echo "Subscription: ${SUBSCRIPTION_ID}"
+echo "Resource Group: ${RESOURCE_GROUP_NAME}"
+echo "Region: ${REGION}"
+echo ""
+
+az account set --subscription "$SUBSCRIPTION_ID"
+
+resolve_storage_account() {
+  if [[ -n "$STORAGE_ACCOUNT" ]]; then
+    return 0
+  fi
+
+  # Reuse an existing storage account from the target resource group.
+  STORAGE_ACCOUNT="$(az storage account list \
+    --resource-group "$RESOURCE_GROUP_NAME" \
+    --query "[?kind=='StorageV2' || kind=='Storage'].name | [0]" \
+    -o tsv 2>/dev/null || true)"
+
+  if [[ -n "$STORAGE_ACCOUNT" ]]; then
+    echo "Auto-discovered storage account: ${STORAGE_ACCOUNT}"
+    return 0
+  fi
+
+  echo "Error: No storage account found in resource group ${RESOURCE_GROUP_NAME}."
+  echo "Set STORAGE_ACCOUNT explicitly, or create one first."
+  exit 1
+}
+
+resolve_app_insights_connection_string() {
+  local target_name="$1"
+  local existing_value
+
+  existing_value="$(az functionapp config appsettings list \
+    --resource-group "$RESOURCE_GROUP_NAME" \
+    --name "$target_name" \
+    --query "[?name=='APPLICATIONINSIGHTS_CONNECTION_STRING'].value | [0]" \
+    -o tsv 2>/dev/null || true)"
+
+  if [[ -n "$existing_value" ]]; then
+    printf '%s' "$existing_value"
+    return 0
+  fi
+
+  az functionapp config appsettings list \
+    --resource-group "$RESOURCE_GROUP_NAME" \
+    --name "$REFERENCE_FUNCTION_NAME" \
+    --query "[?name=='APPLICATIONINSIGHTS_CONNECTION_STRING'].value | [0]" \
+    -o tsv 2>/dev/null || true
+}
+
+apply_runtime_settings() {
+  local target_name="$1"
+  local ai_connection_string
+
+  ai_connection_string="$(resolve_app_insights_connection_string "$target_name")"
+
+  if [[ -z "$ai_connection_string" ]]; then
+    echo "Warning: could not resolve APPLICATIONINSIGHTS_CONNECTION_STRING for ${target_name}."
+    echo "OTEL exporter will fail until the setting is configured."
+  fi
+
+  if [[ -n "$ai_connection_string" ]]; then
+    az functionapp config appsettings set \
+      --resource-group "$RESOURCE_GROUP_NAME" \
+      --name "$target_name" \
+      --settings \
+      "languageWorkers__node__arguments=--require ./dist/src/opentelemetry.js" \
+      "APPLICATIONINSIGHTS_CONNECTION_STRING=$ai_connection_string" >/dev/null
+  else
+    az functionapp config appsettings set \
+      --resource-group "$RESOURCE_GROUP_NAME" \
+      --name "$target_name" \
+      --settings \
+      "languageWorkers__node__arguments=--require ./dist/src/opentelemetry.js" >/dev/null
+  fi
+}
+
+# --- Experiment 1: flex-concurrency-throttle ---
+echo "--- Creating ${THROTTLE_FUNC_NAME} (Flex Consumption) ---"
+if az functionapp show --resource-group "$RESOURCE_GROUP_NAME" --name "$THROTTLE_FUNC_NAME" >/dev/null 2>&1; then
+  echo "Function app ${THROTTLE_FUNC_NAME} already exists, reusing it."
+else
+  resolve_storage_account
+  az functionapp create \
+    --resource-group "$RESOURCE_GROUP_NAME" \
+    --name "$THROTTLE_FUNC_NAME" \
+    --storage-account "$STORAGE_ACCOUNT" \
+    --flexconsumption-location "$REGION" \
+    --runtime node \
+    --runtime-version 22
+fi
+
+echo "Building & deploying flex-concurrency-throttle..."
+cd "$SCRIPT_DIR/flex-concurrency-throttle"
+if [[ ! -d node_modules ]]; then
+  npm install --no-audit --fund=false
+else
+  echo "Using existing node_modules"
+fi
+npm run build
+
+echo "Setting app settings for OTEL preload..."
+apply_runtime_settings "$THROTTLE_FUNC_NAME"
+echo "Configuring throttle app scale: always-ready http=${THROTTLE_ALWAYS_READY_HTTP}, max instances=${THROTTLE_MAX_INSTANCE_COUNT}"
+az functionapp scale config always-ready set \
+  --resource-group "$RESOURCE_GROUP_NAME" \
+  --name "$THROTTLE_FUNC_NAME" \
+  --settings "http=${THROTTLE_ALWAYS_READY_HTTP}" >/dev/null
+az functionapp scale config set \
+  --resource-group "$RESOURCE_GROUP_NAME" \
+  --name "$THROTTLE_FUNC_NAME" \
+  --maximum-instance-count "$THROTTLE_MAX_INSTANCE_COUNT" >/dev/null
+sleep 10
+func azure functionapp publish "$THROTTLE_FUNC_NAME" --javascript
+
+echo ""
+echo "--- Creating ${PER_INSTANCE_FUNC_NAME} (Flex Consumption) ---"
+if az functionapp show --resource-group "$RESOURCE_GROUP_NAME" --name "$PER_INSTANCE_FUNC_NAME" >/dev/null 2>&1; then
+  echo "Function app ${PER_INSTANCE_FUNC_NAME} already exists, reusing it."
+else
+  resolve_storage_account
+  az functionapp create \
+    --resource-group "$RESOURCE_GROUP_NAME" \
+    --name "$PER_INSTANCE_FUNC_NAME" \
+    --storage-account "$STORAGE_ACCOUNT" \
+    --flexconsumption-location "$REGION" \
+    --runtime node \
+    --runtime-version 22
+fi
+
+echo "Building & deploying flex-per-instance-concurrency..."
+cd "$SCRIPT_DIR/flex-per-instance-concurrency"
+if [[ ! -d node_modules ]]; then
+  npm install --no-audit --fund=false
+else
+  echo "Using existing node_modules"
+fi
+npm run build
+
+echo "Setting app settings for OTEL preload..."
+apply_runtime_settings "$PER_INSTANCE_FUNC_NAME"
+sleep 10
+func azure functionapp publish "$PER_INSTANCE_FUNC_NAME" --javascript
+
+# Configure perInstanceConcurrency
+echo ""
+echo "Setting perInstanceConcurrency=2 on ${PER_INSTANCE_FUNC_NAME}..."
+az functionapp scale config set \
+  --resource-group "$RESOURCE_GROUP_NAME" \
+  --name "$PER_INSTANCE_FUNC_NAME" \
+  --trigger-type http \
+  --trigger-settings perInstanceConcurrency=2
+
+echo ""
+echo "=== Deployment complete ==="
+echo ""
+echo "Endpoints:"
+echo "  Throttle:      https://${THROTTLE_FUNC_NAME}.azurewebsites.net/api/http-slow"
+echo "  Per-instance:  https://${PER_INSTANCE_FUNC_NAME}.azurewebsites.net/api/http-slow"
+echo ""
+echo "Run tests:"
+echo "  cd flex-concurrency-throttle && node test-concurrency.js https://${THROTTLE_FUNC_NAME}.azurewebsites.net/api/http-slow 4 3"
+echo "  cd flex-per-instance-concurrency && node test-per-instance.js https://${PER_INSTANCE_FUNC_NAME}.azurewebsites.net/api/http-slow 5 3000 5"

--- a/functions/flex-concurrency-throttle/.funcignore
+++ b/functions/flex-concurrency-throttle/.funcignore
@@ -1,0 +1,13 @@
+*.ts
+.git*
+.vscode
+local.settings.json
+test
+getting_started.md
+node_modules/@types/
+node_modules/azure-functions-core-tools/
+node_modules/typescript/
+node_modules_build
+node_modules_build_bak
+node_modules_deploy
+node_modules_deploy_bak

--- a/functions/flex-concurrency-throttle/README.md
+++ b/functions/flex-concurrency-throttle/README.md
@@ -1,0 +1,85 @@
+# flex-concurrency-throttle
+
+Tests whether `maxConcurrentRequests` / `maxOutstandingRequests` / `dynamicThrottlesEnabled` in `host.json` causes request queuing or HTTP 429 rejection in **Flex Consumption** function apps.
+
+## Hypothesis
+
+In our QA2 EMEA environment, we observed multi-second delays between request arrival and first dependency call in `azfem4iapicustomerservicegraphql`. The suspicion is that `host.json` settings:
+
+```json
+{
+  "extensions": {
+    "http": {
+      "maxConcurrentRequests": 50,
+      "maxOutstandingRequests": 100,
+      "dynamicThrottlesEnabled": true
+    }
+  }
+}
+```
+
+...are applied **globally** (not per-instance) in Flex Consumption, meaning with only 2-4 instances and high traffic, requests queue in the function host before reaching application code.
+
+## Configuration (Restrictive for Testing)
+
+```json
+"maxConcurrentRequests": 6,
+"maxOutstandingRequests": 10,
+"dynamicThrottlesEnabled": true
+```
+
+Scale configuration used by this demo:
+- `always-ready` for `http` group: `2` (two warm HTTP instances)
+- maximum instance count: `2` (keeps topology stable while validating limits)
+
+This means:
+- Up to 6 HTTP requests execute concurrently per host process
+- In this nested demo, one slot per active caller is consumed by `http-slow` while worker calls run
+- Additional worker requests can queue while total outstanding remains under 10
+- HTTP 429 appears when outstanding capacity is exceeded
+- `dynamicThrottlesEnabled` may further reduce limits under CPU/memory pressure
+
+With two warm instances, if limits were strictly global, throughput would stay close to a single-instance cap. If limits are per-instance, effective throughput should improve and queueing pressure should reduce under the same external load.
+
+In the current demo shape (`http-slow` calling `http-worker`), the outer caller request also occupies host capacity. That is why queueing can appear even when your external load seems small.
+
+Practical expectation for a single batch call with `concurrency=24` and `delay=2000`:
+- first group near ~2s (no queue)
+- second group near ~4s (buffered/queued)
+- remaining tail may return 429/503 under pressure
+
+Calibrated run that currently shows all 3 zones in this environment:
+
+```bash
+node test-concurrency.js https://azfe-concurrency-throttle.azurewebsites.net/api/http-slow 24 1 2000
+```
+
+## Local Test
+
+```bash
+npm ci && npm run build
+npm start
+# In another terminal:
+node test-concurrency.js http://localhost:7071/api/http-slow 4 3
+```
+
+## Azure Deploy & Test
+
+```bash
+export RESOURCE_GROUP_NAME=your-rg
+export FUNCTION_NAME=your-flex-func
+export ENDPOINT=https://your-flex-func.azurewebsites.net
+./run.sh
+```
+
+## What to Observe
+
+1. **HTTP 429 responses**: Confirms requests exceed `maxOutstandingRequests`
+2. **Elevated response times** (>2s for a 2s sleep): Indicates queuing
+3. **Same instance ID**: Proves all requests hit one instance (no scale-out triggered)
+
+## Key Questions to Answer
+
+- Are these limits per-instance or global in Flex Consumption?
+- Does `dynamicThrottlesEnabled` compound the issue?
+- How does the platform respond — does it scale out or just reject?

--- a/functions/flex-concurrency-throttle/dist/src/functions/http-health.js
+++ b/functions/flex-concurrency-throttle/dist/src/functions/http-health.js
@@ -1,0 +1,17 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const functions_1 = require("@azure/functions");
+functions_1.app.http("http-health", {
+    methods: ["GET"],
+    authLevel: "anonymous",
+    handler: async (request, context) => {
+        return {
+            status: 200,
+            jsonBody: {
+                status: "ok",
+                timestamp: new Date().toISOString(),
+                instanceId: process.env.WEBSITE_INSTANCE_ID || "local",
+            },
+        };
+    },
+});

--- a/functions/flex-concurrency-throttle/dist/src/functions/http-slow.js
+++ b/functions/flex-concurrency-throttle/dist/src/functions/http-slow.js
@@ -1,0 +1,153 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+const functions_1 = require("@azure/functions");
+const otel = __importStar(require("@opentelemetry/api"));
+functions_1.app.http("http-slow", {
+    methods: ["GET"],
+    authLevel: "anonymous",
+    handler: async (request, context) => {
+        const startedAt = Date.now();
+        const concurrency = parseInt(request.query.get("concurrency") || "4", 10);
+        const batches = parseInt(request.query.get("batches") || "3", 10);
+        const delayMs = parseInt(request.query.get("delay") || "2000", 10);
+        const requestPrefix = request.query.get("id") || "run";
+        const instanceId = process.env.WEBSITE_INSTANCE_ID || "local";
+        const origin = new URL(request.url).origin;
+        const workerUrl = `${origin}/api/http-worker`;
+        const tracer = otel.trace.getTracer(process.env.WEBSITE_SITE_NAME || "flex-concurrency-throttle");
+        context.log(`[caller] START concurrency=${concurrency} batches=${batches} delay=${delayMs}ms worker=${workerUrl} instance=${instanceId}`);
+        const result = await tracer.startActiveSpan("orchestrateWorkerBatches", {
+            kind: otel.SpanKind.INTERNAL,
+            attributes: {
+                "request.concurrency": concurrency,
+                "request.batches": batches,
+                "request.delay_ms": delayMs,
+                "instance.id": instanceId,
+                "concurrency.test": "maxConcurrentRequests",
+                "function.role": "caller",
+            },
+        }, async (span) => {
+            const batchResults = [];
+            let totalSuccess = 0;
+            let totalThrottled = 0;
+            let totalErrors = 0;
+            const workerInstances = new Set();
+            try {
+                for (let batch = 1; batch <= batches; batch++) {
+                    const batchStart = Date.now();
+                    span.addEvent("batch.start", { batch_id: batch, concurrency });
+                    context.log(`[caller] BATCH ${batch} START concurrency=${concurrency}`);
+                    const requests = Array.from({ length: concurrency }, (_, idx) => {
+                        const reqId = `${requestPrefix}-b${batch}-r${idx + 1}`;
+                        const url = `${workerUrl}?id=${encodeURIComponent(reqId)}&batch=${batch}&delay=${delayMs}`;
+                        const start = Date.now();
+                        return fetch(url)
+                            .then(async (response) => {
+                            const elapsedMs = Date.now() - start;
+                            if (response.status === 200) {
+                                const body = (await response.json());
+                                if (body.instanceId) {
+                                    workerInstances.add(body.instanceId);
+                                }
+                                return { id: reqId, status: 200, elapsedMs, instanceId: body.instanceId };
+                            }
+                            return { id: reqId, status: response.status, elapsedMs, error: `HTTP ${response.status}` };
+                        })
+                            .catch((error) => {
+                            const elapsedMs = Date.now() - start;
+                            return { id: reqId, status: "ERR", elapsedMs, error: error.message };
+                        });
+                    });
+                    const settled = await Promise.all(requests);
+                    const batchSuccess = settled.filter((r) => r.status === 200).length;
+                    const batchThrottled = settled.filter((r) => r.status === 429 || r.status === 503).length;
+                    const batchErrors = settled.length - batchSuccess - batchThrottled;
+                    totalSuccess += batchSuccess;
+                    totalThrottled += batchThrottled;
+                    totalErrors += batchErrors;
+                    span.addEvent("batch.end", {
+                        batch_id: batch,
+                        duration_ms: Date.now() - batchStart,
+                        success_count: batchSuccess,
+                        throttled_count: batchThrottled,
+                        error_count: batchErrors,
+                    });
+                    context.log(`[caller] BATCH ${batch} END success=${batchSuccess} throttled=${batchThrottled} errors=${batchErrors} duration=${Date.now() - batchStart}ms`);
+                    batchResults.push({
+                        batchId: batch,
+                        summary: { successCount: batchSuccess, throttledCount: batchThrottled, errorCount: batchErrors },
+                        results: settled,
+                    });
+                }
+                const totalDurationMs = Date.now() - startedAt;
+                span.setAttribute("total.duration_ms", totalDurationMs);
+                span.setAttribute("summary.success_count", totalSuccess);
+                span.setAttribute("summary.throttled_count", totalThrottled);
+                span.setAttribute("summary.error_count", totalErrors);
+                span.setAttribute("summary.unique_worker_instances", workerInstances.size);
+                context.log(`[caller] END totalDuration=${totalDurationMs}ms success=${totalSuccess} throttled=${totalThrottled} errors=${totalErrors} workerInstances=${workerInstances.size}`);
+                return {
+                    status: 200,
+                    jsonBody: {
+                        startTime: new Date(startedAt).toISOString(),
+                        endTime: new Date().toISOString(),
+                        totalDurationMs,
+                        scenario: {
+                            concurrency,
+                            batches,
+                            delayMs,
+                            callerInstanceId: instanceId,
+                            workerUrl,
+                        },
+                        summary: {
+                            totalRequests: concurrency * batches,
+                            successCount: totalSuccess,
+                            throttledCount: totalThrottled,
+                            errorCount: totalErrors,
+                            uniqueWorkerInstances: workerInstances.size,
+                        },
+                        batchResults,
+                        callerTraceId: span.spanContext().traceId,
+                    },
+                };
+            }
+            finally {
+                span.end();
+            }
+        });
+        return result;
+    },
+});

--- a/functions/flex-concurrency-throttle/dist/src/functions/http-worker.js
+++ b/functions/flex-concurrency-throttle/dist/src/functions/http-worker.js
@@ -1,0 +1,87 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+const functions_1 = require("@azure/functions");
+const promises_1 = require("timers/promises");
+const otel = __importStar(require("@opentelemetry/api"));
+functions_1.app.http("http-worker", {
+    methods: ["GET"],
+    authLevel: "anonymous",
+    handler: async (request, context) => {
+        const startTime = Date.now();
+        const delayMs = parseInt(request.query.get("delay") || "2000", 10);
+        const requestId = request.query.get("id") || "unknown";
+        const batchId = parseInt(request.query.get("batch") || "0", 10);
+        const instanceId = process.env.WEBSITE_INSTANCE_ID || "local";
+        const tracer = otel.trace.getTracer(process.env.WEBSITE_SITE_NAME || "flex-concurrency-throttle");
+        return tracer.startActiveSpan("workerSleep", {
+            kind: otel.SpanKind.INTERNAL,
+            attributes: {
+                "request.id": requestId,
+                "batch.id": batchId,
+                "request.delay_ms": delayMs,
+                "instance.id": instanceId,
+                "function.role": "worker",
+            },
+        }, async (span) => {
+            try {
+                span.addEvent("worker.start", { delay_ms: delayMs, batch_id: batchId });
+                context.log(`[worker][${requestId}] START batch=${batchId} delay=${delayMs}ms instance=${instanceId}`);
+                await (0, promises_1.setTimeout)(delayMs);
+                const duration = Date.now() - startTime;
+                span.addEvent("worker.end", { duration_ms: duration });
+                span.setAttribute("request.actual_duration_ms", duration);
+                context.log(`[worker][${requestId}] END batch=${batchId} duration=${duration}ms instance=${instanceId}`);
+                return {
+                    status: 200,
+                    jsonBody: {
+                        requestId,
+                        batchId,
+                        startTime: new Date(startTime).toISOString(),
+                        endTime: new Date().toISOString(),
+                        durationMs: duration,
+                        delayMs,
+                        overheadMs: duration - delayMs,
+                        instanceId,
+                        traceId: span.spanContext().traceId,
+                    },
+                };
+            }
+            finally {
+                span.end();
+            }
+        });
+    },
+});

--- a/functions/flex-concurrency-throttle/dist/src/opentelemetry.js
+++ b/functions/flex-concurrency-throttle/dist/src/opentelemetry.js
@@ -1,0 +1,51 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ConsoleSpanExporter = void 0;
+console.log(">>> OTEL loading");
+const start = performance.now();
+const functions_opentelemetry_instrumentation_1 = require("@azure/functions-opentelemetry-instrumentation");
+const monitor_opentelemetry_exporter_1 = require("@azure/monitor-opentelemetry-exporter");
+const instrumentation_http_1 = require("@opentelemetry/instrumentation-http");
+const instrumentation_undici_1 = require("@opentelemetry/instrumentation-undici");
+const instrumentation_1 = require("@opentelemetry/instrumentation");
+const resources_1 = require("@opentelemetry/resources");
+const sdk_logs_1 = require("@opentelemetry/sdk-logs");
+const sdk_trace_node_1 = require("@opentelemetry/sdk-trace-node");
+const core_1 = require("@opentelemetry/core");
+// Console exporter for debugging — prints spans to stdout
+class ConsoleSpanExporter {
+    export(spans, resultCallback) {
+        for (const span of spans) {
+            console.log(`[SPAN] ${span.name} | duration=${(span.duration[0] * 1000 + span.duration[1] / 1e6).toFixed(1)}ms | status=${span.status.code} | traceId=${span.spanContext().traceId}`);
+        }
+        resultCallback({ code: core_1.ExportResultCode.SUCCESS });
+    }
+    async shutdown() { }
+}
+exports.ConsoleSpanExporter = ConsoleSpanExporter;
+let resource = (0, resources_1.detectResources)({
+    detectors: [resources_1.envDetector, resources_1.hostDetector, resources_1.osDetector, resources_1.processDetector],
+});
+resource = resource.merge((0, resources_1.resourceFromAttributes)({ ["service.name"]: process.env.WEBSITE_SITE_NAME || "flex-concurrency-throttle" }));
+const tracerProvider = new sdk_trace_node_1.NodeTracerProvider({
+    resource,
+    spanProcessors: [
+        new sdk_trace_node_1.BatchSpanProcessor(new monitor_opentelemetry_exporter_1.AzureMonitorTraceExporter()),
+        new sdk_trace_node_1.SimpleSpanProcessor(new ConsoleSpanExporter()),
+    ],
+});
+tracerProvider.register();
+const loggerProvider = new sdk_logs_1.LoggerProvider({
+    resource,
+    processors: [new sdk_logs_1.BatchLogRecordProcessor(new monitor_opentelemetry_exporter_1.AzureMonitorLogExporter())],
+});
+(0, instrumentation_1.registerInstrumentations)({
+    tracerProvider,
+    loggerProvider,
+    instrumentations: [
+        new instrumentation_http_1.HttpInstrumentation(),
+        new instrumentation_undici_1.UndiciInstrumentation(),
+        new functions_opentelemetry_instrumentation_1.AzureFunctionsInstrumentation(),
+    ],
+});
+console.log(`>>> OTEL loaded in ${(performance.now() - start).toFixed(0)}ms`);

--- a/functions/flex-concurrency-throttle/host.json
+++ b/functions/flex-concurrency-throttle/host.json
@@ -1,0 +1,28 @@
+{
+  "version": "2.0",
+  "telemetryMode": "OpenTelemetry",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": false
+      }
+    },
+    "logLevel": {
+      "default": "Information",
+      "Host.Results": "Information",
+      "Function": "Information"
+    }
+  },
+  "extensions": {
+    "http": {
+      "routePrefix": "api",
+      "maxConcurrentRequests": 2,
+      "maxOutstandingRequests": 3,
+      "dynamicThrottlesEnabled": true
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/functions/flex-concurrency-throttle/local.settings.json
+++ b/functions/flex-concurrency-throttle/local.settings.json
@@ -1,0 +1,7 @@
+{
+  "IsEncrypted": true,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "CfDJ8B4RxF0WfPBJumultKKGtRcFMqKKwDYGCyvB0T6u06AKzTNv6fCliRbw6sGnN34NFwu0JcibYMO3iNSm9BFjlQi2FvWQbxbi7Si52IUbkch24kJ9h3kFwEfCP+P/ZQfQzw=="
+  },
+  "ConnectionStrings": {}
+}

--- a/functions/flex-concurrency-throttle/package-lock.json
+++ b/functions/flex-concurrency-throttle/package-lock.json
@@ -1,0 +1,1259 @@
+{
+  "name": "@msft-azure-test-functions/flex-concurrency-throttle",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@msft-azure-test-functions/flex-concurrency-throttle",
+      "version": "1.0.0",
+      "dependencies": {
+        "@azure/functions": "4.8.0",
+        "@azure/functions-opentelemetry-instrumentation": "0.2.0",
+        "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.32",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/api-logs": "0.205.0",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/instrumentation": "0.205.0",
+        "@opentelemetry/instrumentation-http": "0.205.0",
+        "@opentelemetry/instrumentation-undici": "0.16.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/sdk-logs": "0.205.0",
+        "@opentelemetry/sdk-trace-node": "2.1.0"
+      },
+      "devDependencies": {
+        "@types/node": "22.18.0",
+        "azure-functions-core-tools": "4.2.2",
+        "typescript": "5.9.2"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.2.tgz",
+      "integrity": "sha512-1D2LpsU7y9xrqKjdIbsB7PlrRePw0xsVV8p+AKTlzITrWmscajryfJCdDJB/oGwvDI5HmRo04eMMADB67uwAwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.24.0.tgz",
+      "integrity": "sha512-PpLsoDQ3AMmKZ0VU+0GrmqMxgp/sExjlVm4R+nLWngeoEGAzOIPVifaxKGU5gMv+nWELUoHfvrolWD+ZS/nFJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/functions": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.0.tgz",
+      "integrity": "sha512-LNtl3xZNE40vE7+SIST+GYQX5cnnI1M65fXPi26l9XCdPakuQrz54lHv+qQQt1GG5JbqLfQk75iM7A6Y9O+2dQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.7.0",
+        "long": "^4.0.0",
+        "undici": "^5.29.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@azure/functions-opentelemetry-instrumentation": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/functions-opentelemetry-instrumentation/-/functions-opentelemetry-instrumentation-0.2.0.tgz",
+      "integrity": "sha512-IvgsbgfIeuR5Q5IDm2ZgiW9b4PumMHZF0UH99zbKlq+YoaMZWucU2rpsUhFugoaPCtsZtEbKA17prv3+URbI9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.52.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/monitor-opentelemetry-exporter": {
+      "version": "1.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@azure/monitor-opentelemetry-exporter/-/monitor-opentelemetry-exporter-1.0.0-beta.32.tgz",
+      "integrity": "sha512-Tk5Tv8KwHhKCQlXET/7ZLtjBv1Zi4lmPTadKTQ9KCURRJWdt+6hu5ze52Tlp2pVeg3mg+MRQ9vhWvVNXMZAp/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.19.0",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.200.0",
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/resources": "^2.0.0",
+        "@opentelemetry/sdk-logs": "^0.200.0",
+        "@opentelemetry/sdk-metrics": "^2.0.0",
+        "@opentelemetry/sdk-trace-base": "^2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.32.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/monitor-opentelemetry-exporter/node_modules/@opentelemetry/api-logs": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.200.0.tgz",
+      "integrity": "sha512-IKJBQxh91qJ+3ssRly5hYEJ8NDHu9oY/B1PXVSCWf7zytmYO9RNLB0Ox9XQ/fJ8m6gY6Q6NtBWlmXfaXt5Uc4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@azure/monitor-opentelemetry-exporter/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@azure/monitor-opentelemetry-exporter/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@azure/monitor-opentelemetry-exporter/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.200.0.tgz",
+      "integrity": "sha512-VZG870063NLfObmQQNtCVcdXXLzI3vOjjrRENmU37HYiPFa0ZXpXVDsTD02Nh3AT3xYJzQaWKl2X2lQ2l7TWJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.200.0",
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.205.0.tgz",
+      "integrity": "sha512-wBlPk1nFB37Hsm+3Qy73yQSobVn28F4isnWIBvKpd5IUH/eat8bwcL02H9yzmHyyPmukeccSl2mbN5sDQZYnPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.1.0.tgz",
+      "integrity": "sha512-zOyetmZppnwTyPrt4S7jMfXiSX9yyfF0hxlA8B5oo2TtKl+/RGCy7fi4DrBfIf3lCPrkKsRBWZZD7RFojK7FDg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.205.0.tgz",
+      "integrity": "sha512-cgvm7tvQdu9Qo7VurJP84wJ7ZV9F6WqDDGZpUc6rUEXwjV7/bXWs0kaYp9v+1Vh1+3TZCD3i6j/lUBcPhu8NhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.205.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.205.0.tgz",
+      "integrity": "sha512-6fOgRlV7ypBuEzCQP7vXkLQxz3UL1FhE24rAlMRbwGvPAnZLvutcG/fq9FI/n+VU23dOpYexocYsXCf5oy/AXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/instrumentation": "0.205.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0",
+        "forwarded-parse": "2.1.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-undici": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.16.0.tgz",
+      "integrity": "sha512-sky42QpDmsHbrmE02sCEk7kdug2uTB4w5OwLpfHKom/5vbzTJZDoaM68YpCq0vTQ9QwL/DIDGwjdaTcU+XXCxQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.205.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
+      "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.205.0.tgz",
+      "integrity": "sha512-nyqhNQ6eEzPWQU60Nc7+A5LIq8fz3UeIzdEVBQYefB4+msJZ2vuVtRuk9KxPMw1uHoHDtYEwkr2Ct0iG29jU8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.205.0",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.9.0.tgz",
+      "integrity": "sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
+      "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.1.0.tgz",
+      "integrity": "sha512-SvVlBFc/jI96u/mmlKm86n9BbTCbQ35nsPoOohqJX6DXH92K0kTe73zGY5r8xoI1QkjR9PizszVJLzMC966y9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.1.0",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/sdk-trace-base": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz",
+      "integrity": "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.18.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.0.tgz",
+      "integrity": "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.6.tgz",
+      "integrity": "sha512-jIXhD0eWQ1JA6ln/5Dltyx22UxWNrw0hZmhy2rlv6m6KgF7kplHx3g0fzi09lNmTJQRR91OlemYp3xFnvDK9og==",
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/azure-functions-core-tools": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/azure-functions-core-tools/-/azure-functions-core-tools-4.2.2.tgz",
+      "integrity": "sha512-TxafmfFZCOdv9hoU29W/IPEiwlwTT3jj4ZnM58DttG+LLxPz1Xc2+afSzQ502WpemHI9wvGLYXb55KDGCwKKRw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "hasShrinkwrap": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "chalk": "3.0.0",
+        "extract-zip": "^2.0.1",
+        "https-proxy-agent": "5.0.1",
+        "progress": "2.0.3",
+        "rimraf": "4.4.1"
+      },
+      "bin": {
+        "azfun": "lib/main.js",
+        "azurefunctions": "lib/main.js",
+        "func": "lib/main.js"
+      },
+      "engines": {
+        "node": ">=6.9.1"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
+    "node_modules/azure-functions-core-tools/node_modules/@types/node": {
+      "version": "18.15.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/azure-functions-core-tools/node_modules/@types/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/ansi-styles": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.0.tgz",
+      "integrity": "sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==",
+      "dev": true,
+      "dependencies": {
+        "@types/color-name": "^1.1.1",
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/azure-functions-core-tools/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/azure-functions-core-tools/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/azure-functions-core-tools/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/glob": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/azure-functions-core-tools/node_modules/minimatch": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/azure-functions-core-tools/node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
+    },
+    "node_modules/azure-functions-core-tools/node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/rimraf": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
+      "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^9.2.0"
+      },
+      "bin": {
+        "rimraf": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/supports-color": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "node_modules/azure-functions-core-tools/node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/forwarded-parse": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+      "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
+      "license": "MIT"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
+      "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+      "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/functions/flex-concurrency-throttle/package.json
+++ b/functions/flex-concurrency-throttle/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@msft-azure-test-functions/flex-concurrency-throttle",
+  "version": "1.0.0",
+  "main": "dist/src/functions/*.js",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "start": "func start"
+  },
+  "dependencies": {
+    "@azure/functions": "4.8.0",
+    "@azure/functions-opentelemetry-instrumentation": "0.2.0",
+    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.32",
+    "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/api-logs": "0.205.0",
+    "@opentelemetry/core": "2.1.0",
+    "@opentelemetry/instrumentation": "0.205.0",
+    "@opentelemetry/instrumentation-http": "0.205.0",
+    "@opentelemetry/instrumentation-undici": "0.16.0",
+    "@opentelemetry/resources": "2.1.0",
+    "@opentelemetry/sdk-logs": "0.205.0",
+    "@opentelemetry/sdk-trace-node": "2.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "22.18.0",
+    "azure-functions-core-tools": "4.2.2",
+    "typescript": "5.9.2"
+  },
+  "overrides": {
+    "@azure/functions-opentelemetry-instrumentation": {
+      "@opentelemetry/api-logs": "0.205.0",
+      "@opentelemetry/instrumentation": "0.205.0"
+    }
+  }
+}

--- a/functions/flex-concurrency-throttle/run.sh
+++ b/functions/flex-concurrency-throttle/run.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+set -euo pipefail
+
+# Deploy and test flex-concurrency-throttle experiment
+#
+# Optional env vars (all have defaults):
+#   SUBSCRIPTION_ID   - Azure subscription
+#   RESOURCE_GROUP_NAME - Azure resource group
+#   FUNCTION_NAME     - Function app name (Flex Consumption)
+#   REGION            - Azure region
+#   STORAGE_ACCOUNT   - Storage account name (auto-discovered if omitted)
+#   REFERENCE_FUNCTION_NAME - Existing app from which to reuse AI connection string
+#   ALWAYS_READY_HTTP - Always-ready HTTP instances for this app
+#   MAX_INSTANCE_COUNT - Max instances cap for this app
+#   APIM_ENDPOINT     - Existing APIM base URL (preferred for testing via APIM)
+#   FUNCTION_ENDPOINT - Explicit function endpoint override
+
+SUBSCRIPTION_ID="${SUBSCRIPTION_ID:-0ebbefb8-987e-4fcd-bbbc-41d704f2d586}"
+RESOURCE_GROUP_NAME="${RESOURCE_GROUP_NAME:-playground-kamil}"
+FUNCTION_NAME="${FUNCTION_NAME:-azfe-concurrency-throttle}"
+REGION="${REGION:-westeurope}"
+STORAGE_ACCOUNT="${STORAGE_ACCOUNT:-}"
+REFERENCE_FUNCTION_NAME="${REFERENCE_FUNCTION_NAME:-azure-test-otel}"
+ALWAYS_READY_HTTP="${ALWAYS_READY_HTTP:-2}"
+MAX_INSTANCE_COUNT="${MAX_INSTANCE_COUNT:-2}"
+APIM_ENDPOINT="${APIM_ENDPOINT:-}"
+FUNCTION_ENDPOINT="${FUNCTION_ENDPOINT:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "Using subscription: ${SUBSCRIPTION_ID}"
+az account set --subscription "$SUBSCRIPTION_ID"
+
+resolve_storage_account() {
+  if [[ -n "$STORAGE_ACCOUNT" ]]; then
+    return 0
+  fi
+
+  STORAGE_ACCOUNT="$(az storage account list \
+    --resource-group "$RESOURCE_GROUP_NAME" \
+    --query "[?kind=='StorageV2' || kind=='Storage'].name | [0]" \
+    -o tsv 2>/dev/null || true)"
+
+  if [[ -z "$STORAGE_ACCOUNT" ]]; then
+    echo "Error: No storage account found in ${RESOURCE_GROUP_NAME}."
+    echo "Set STORAGE_ACCOUNT explicitly, or create one first."
+    exit 1
+  fi
+
+  echo "Auto-discovered storage account: ${STORAGE_ACCOUNT}"
+}
+
+ensure_function_app_exists() {
+  if az functionapp show --resource-group "$RESOURCE_GROUP_NAME" --name "$FUNCTION_NAME" >/dev/null 2>&1; then
+    echo "Function app ${FUNCTION_NAME} already exists, reusing it."
+    return 0
+  fi
+
+  resolve_storage_account
+  echo "Creating Function App ${FUNCTION_NAME} in ${RESOURCE_GROUP_NAME}..."
+  az functionapp create \
+    --resource-group "$RESOURCE_GROUP_NAME" \
+    --name "$FUNCTION_NAME" \
+    --storage-account "$STORAGE_ACCOUNT" \
+    --flexconsumption-location "$REGION" \
+    --runtime node \
+    --runtime-version 22
+}
+
+resolve_app_insights_connection_string() {
+  local existing_value
+
+  existing_value="$(az functionapp config appsettings list \
+    --resource-group "$RESOURCE_GROUP_NAME" \
+    --name "$FUNCTION_NAME" \
+    --query "[?name=='APPLICATIONINSIGHTS_CONNECTION_STRING'].value | [0]" \
+    -o tsv 2>/dev/null || true)"
+
+  if [[ -n "$existing_value" ]]; then
+    printf '%s' "$existing_value"
+    return 0
+  fi
+
+  az functionapp config appsettings list \
+    --resource-group "$RESOURCE_GROUP_NAME" \
+    --name "$REFERENCE_FUNCTION_NAME" \
+    --query "[?name=='APPLICATIONINSIGHTS_CONNECTION_STRING'].value | [0]" \
+    -o tsv 2>/dev/null || true
+}
+
+echo "=== flex-concurrency-throttle ==="
+echo ""
+
+# Build
+echo "Building..."
+if [[ ! -d node_modules ]]; then
+  npm install --no-audit --fund=false
+else
+  echo "Using existing node_modules"
+fi
+npm run build
+
+# Deploy
+ensure_function_app_exists
+echo "Setting OTEL preload app setting..."
+ai_connection_string="$(resolve_app_insights_connection_string)"
+if [[ -n "$ai_connection_string" ]]; then
+  az functionapp config appsettings set \
+    --resource-group "$RESOURCE_GROUP_NAME" \
+    --name "$FUNCTION_NAME" \
+    --settings \
+    "languageWorkers__node__arguments=--require ./dist/src/opentelemetry.js" \
+    "APPLICATIONINSIGHTS_CONNECTION_STRING=$ai_connection_string" >/dev/null
+else
+  echo "Warning: could not resolve APPLICATIONINSIGHTS_CONNECTION_STRING."
+  az functionapp config appsettings set \
+    --resource-group "$RESOURCE_GROUP_NAME" \
+    --name "$FUNCTION_NAME" \
+    --settings \
+    "languageWorkers__node__arguments=--require ./dist/src/opentelemetry.js" >/dev/null
+fi
+
+echo "Configuring scale: always-ready http=${ALWAYS_READY_HTTP}, max instances=${MAX_INSTANCE_COUNT}"
+az functionapp scale config always-ready set \
+  --resource-group "$RESOURCE_GROUP_NAME" \
+  --name "$FUNCTION_NAME" \
+  --settings "http=${ALWAYS_READY_HTTP}" >/dev/null
+az functionapp scale config set \
+  --resource-group "$RESOURCE_GROUP_NAME" \
+  --name "$FUNCTION_NAME" \
+  --maximum-instance-count "$MAX_INSTANCE_COUNT" >/dev/null
+
+echo "Waiting 10s for deployment to stabilize..."
+sleep 10
+
+echo "Deploying to ${FUNCTION_NAME} in ${RESOURCE_GROUP_NAME}..."
+func azure functionapp publish "$FUNCTION_NAME" --javascript
+
+# Test
+if [[ -n "$APIM_ENDPOINT" ]]; then
+  FUNCTION_ENDPOINT="$APIM_ENDPOINT"
+fi
+
+if [[ -z "$FUNCTION_ENDPOINT" ]]; then
+  host_name="$(az functionapp show \
+    --name "$FUNCTION_NAME" \
+    --resource-group "$RESOURCE_GROUP_NAME" \
+    --query "properties.defaultHostName" -o tsv)"
+  FUNCTION_ENDPOINT="https://${host_name}"
+fi
+
+echo ""
+echo "Testing against: ${FUNCTION_ENDPOINT}/api/http-slow"
+echo ""
+
+# Test 1: Low concurrency (should succeed)
+echo "--- Test 1: 2 concurrent requests (within limit) ---"
+node test-concurrency.js "${FUNCTION_ENDPOINT}/api/http-slow" 2 1 2000
+
+echo ""
+echo "--- Test 2: 4 concurrent requests (exceeds limit) ---"
+node test-concurrency.js "${FUNCTION_ENDPOINT}/api/http-slow" 4 3 2000
+
+echo ""
+echo "--- Test 3: 6 concurrent requests (well above limit) ---"
+node test-concurrency.js "${FUNCTION_ENDPOINT}/api/http-slow" 6 2 2000

--- a/functions/flex-concurrency-throttle/src/functions/http-health.ts
+++ b/functions/flex-concurrency-throttle/src/functions/http-health.ts
@@ -1,0 +1,16 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
+
+app.http("http-health", {
+  methods: ["GET"],
+  authLevel: "anonymous",
+  handler: async (request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> => {
+    return {
+      status: 200,
+      jsonBody: {
+        status: "ok",
+        timestamp: new Date().toISOString(),
+        instanceId: process.env.WEBSITE_INSTANCE_ID || "local",
+      },
+    };
+  },
+});

--- a/functions/flex-concurrency-throttle/src/functions/http-slow.ts
+++ b/functions/flex-concurrency-throttle/src/functions/http-slow.ts
@@ -1,0 +1,145 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
+import * as otel from "@opentelemetry/api";
+
+app.http("http-slow", {
+  methods: ["GET"],
+  authLevel: "anonymous",
+  handler: async (request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> => {
+    const startedAt = Date.now();
+    const concurrency = parseInt(request.query.get("concurrency") || "4", 10);
+    const batches = parseInt(request.query.get("batches") || "3", 10);
+    const delayMs = parseInt(request.query.get("delay") || "2000", 10);
+    const requestPrefix = request.query.get("id") || "run";
+    const instanceId = process.env.WEBSITE_INSTANCE_ID || "local";
+    const origin = new URL(request.url).origin;
+    const workerUrl = `${origin}/api/http-worker`;
+    const tracer = otel.trace.getTracer(process.env.WEBSITE_SITE_NAME || "flex-concurrency-throttle");
+
+    context.log(`[caller] START concurrency=${concurrency} batches=${batches} delay=${delayMs}ms worker=${workerUrl} instance=${instanceId}`);
+
+    const result = await tracer.startActiveSpan(
+      "orchestrateWorkerBatches",
+      {
+        kind: otel.SpanKind.INTERNAL,
+        attributes: {
+          "request.concurrency": concurrency,
+          "request.batches": batches,
+          "request.delay_ms": delayMs,
+          "instance.id": instanceId,
+          "concurrency.test": "maxConcurrentRequests",
+          "function.role": "caller",
+        },
+      },
+      async (span) => {
+        const batchResults: Array<{
+          batchId: number;
+          summary: { successCount: number; throttledCount: number; errorCount: number };
+          results: Array<{ id: string; status: number | string; elapsedMs: number; instanceId?: string; error?: string }>;
+        }> = [];
+
+        let totalSuccess = 0;
+        let totalThrottled = 0;
+        let totalErrors = 0;
+        const workerInstances = new Set<string>();
+
+        try {
+          for (let batch = 1; batch <= batches; batch++) {
+            const batchStart = Date.now();
+            span.addEvent("batch.start", { batch_id: batch, concurrency });
+            context.log(`[caller] BATCH ${batch} START concurrency=${concurrency}`);
+
+            const requests = Array.from({ length: concurrency }, (_, idx) => {
+              const reqId = `${requestPrefix}-b${batch}-r${idx + 1}`;
+              const url = `${workerUrl}?id=${encodeURIComponent(reqId)}&batch=${batch}&delay=${delayMs}`;
+              const start = Date.now();
+
+              return fetch(url)
+                .then(async (response) => {
+                  const elapsedMs = Date.now() - start;
+                  if (response.status === 200) {
+                    const body = (await response.json()) as { instanceId?: string };
+                    if (body.instanceId) {
+                      workerInstances.add(body.instanceId);
+                    }
+                    return { id: reqId, status: 200, elapsedMs, instanceId: body.instanceId };
+                  }
+                  return { id: reqId, status: response.status, elapsedMs, error: `HTTP ${response.status}` };
+                })
+                .catch((error: Error) => {
+                  const elapsedMs = Date.now() - start;
+                  return { id: reqId, status: "ERR", elapsedMs, error: error.message };
+                });
+            });
+
+            const settled = await Promise.all(requests);
+            const batchSuccess = settled.filter((r) => r.status === 200).length;
+            const batchThrottled = settled.filter((r) => r.status === 429 || r.status === 503).length;
+            const batchErrors = settled.length - batchSuccess - batchThrottled;
+
+            totalSuccess += batchSuccess;
+            totalThrottled += batchThrottled;
+            totalErrors += batchErrors;
+
+            span.addEvent("batch.end", {
+              batch_id: batch,
+              duration_ms: Date.now() - batchStart,
+              success_count: batchSuccess,
+              throttled_count: batchThrottled,
+              error_count: batchErrors,
+            });
+
+            context.log(
+              `[caller] BATCH ${batch} END success=${batchSuccess} throttled=${batchThrottled} errors=${batchErrors} duration=${Date.now() - batchStart}ms`
+            );
+
+            batchResults.push({
+              batchId: batch,
+              summary: { successCount: batchSuccess, throttledCount: batchThrottled, errorCount: batchErrors },
+              results: settled,
+            });
+          }
+
+          const totalDurationMs = Date.now() - startedAt;
+          span.setAttribute("total.duration_ms", totalDurationMs);
+          span.setAttribute("summary.success_count", totalSuccess);
+          span.setAttribute("summary.throttled_count", totalThrottled);
+          span.setAttribute("summary.error_count", totalErrors);
+          span.setAttribute("summary.unique_worker_instances", workerInstances.size);
+
+          context.log(
+            `[caller] END totalDuration=${totalDurationMs}ms success=${totalSuccess} throttled=${totalThrottled} errors=${totalErrors} workerInstances=${workerInstances.size}`
+          );
+
+          return {
+            status: 200 as const,
+            jsonBody: {
+              startTime: new Date(startedAt).toISOString(),
+              endTime: new Date().toISOString(),
+              totalDurationMs,
+              scenario: {
+                concurrency,
+                batches,
+                delayMs,
+                callerInstanceId: instanceId,
+                workerUrl,
+              },
+              summary: {
+                totalRequests: concurrency * batches,
+                successCount: totalSuccess,
+                throttledCount: totalThrottled,
+                errorCount: totalErrors,
+                uniqueWorkerInstances: workerInstances.size,
+              },
+              batchResults,
+              callerTraceId: span.spanContext().traceId,
+            },
+          };
+        } finally {
+          span.end();
+        }
+      }
+    );
+
+    return result;
+  },
+});

--- a/functions/flex-concurrency-throttle/src/functions/http-worker.ts
+++ b/functions/flex-concurrency-throttle/src/functions/http-worker.ts
@@ -1,0 +1,61 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
+import { setTimeout } from "timers/promises";
+import * as otel from "@opentelemetry/api";
+
+app.http("http-worker", {
+  methods: ["GET"],
+  authLevel: "anonymous",
+  handler: async (request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> => {
+    const startTime = Date.now();
+    const delayMs = parseInt(request.query.get("delay") || "2000", 10);
+    const requestId = request.query.get("id") || "unknown";
+    const batchId = parseInt(request.query.get("batch") || "0", 10);
+    const instanceId = process.env.WEBSITE_INSTANCE_ID || "local";
+    const tracer = otel.trace.getTracer(process.env.WEBSITE_SITE_NAME || "flex-concurrency-throttle");
+
+    return tracer.startActiveSpan(
+      "workerSleep",
+      {
+        kind: otel.SpanKind.INTERNAL,
+        attributes: {
+          "request.id": requestId,
+          "batch.id": batchId,
+          "request.delay_ms": delayMs,
+          "instance.id": instanceId,
+          "function.role": "worker",
+        },
+      },
+      async (span) => {
+        try {
+          span.addEvent("worker.start", { delay_ms: delayMs, batch_id: batchId });
+          context.log(`[worker][${requestId}] START batch=${batchId} delay=${delayMs}ms instance=${instanceId}`);
+
+          await setTimeout(delayMs);
+
+          const duration = Date.now() - startTime;
+          span.addEvent("worker.end", { duration_ms: duration });
+          span.setAttribute("request.actual_duration_ms", duration);
+
+          context.log(`[worker][${requestId}] END batch=${batchId} duration=${duration}ms instance=${instanceId}`);
+
+          return {
+            status: 200,
+            jsonBody: {
+              requestId,
+              batchId,
+              startTime: new Date(startTime).toISOString(),
+              endTime: new Date().toISOString(),
+              durationMs: duration,
+              delayMs,
+              overheadMs: duration - delayMs,
+              instanceId,
+              traceId: span.spanContext().traceId,
+            },
+          };
+        } finally {
+          span.end();
+        }
+      }
+    );
+  },
+});

--- a/functions/flex-concurrency-throttle/src/opentelemetry.ts
+++ b/functions/flex-concurrency-throttle/src/opentelemetry.ts
@@ -1,0 +1,75 @@
+console.log(">>> OTEL loading");
+const start = performance.now();
+
+import { AzureFunctionsInstrumentation } from "@azure/functions-opentelemetry-instrumentation";
+import {
+  AzureMonitorLogExporter,
+  AzureMonitorTraceExporter,
+} from "@azure/monitor-opentelemetry-exporter";
+import { HttpInstrumentation } from "@opentelemetry/instrumentation-http";
+import { UndiciInstrumentation } from "@opentelemetry/instrumentation-undici";
+import { registerInstrumentations } from "@opentelemetry/instrumentation";
+import {
+  detectResources,
+  envDetector,
+  hostDetector,
+  osDetector,
+  processDetector,
+  resourceFromAttributes,
+} from "@opentelemetry/resources";
+import { LoggerProvider, BatchLogRecordProcessor } from "@opentelemetry/sdk-logs";
+import {
+  NodeTracerProvider,
+  BatchSpanProcessor,
+  SimpleSpanProcessor,
+  SpanExporter,
+  ReadableSpan,
+} from "@opentelemetry/sdk-trace-node";
+import { ExportResultCode } from "@opentelemetry/core";
+import type { ExportResult } from "@opentelemetry/core";
+
+// Console exporter for debugging — prints spans to stdout
+export class ConsoleSpanExporter implements SpanExporter {
+  export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
+    for (const span of spans) {
+      console.log(
+        `[SPAN] ${span.name} | duration=${(span.duration[0] * 1000 + span.duration[1] / 1e6).toFixed(1)}ms | status=${span.status.code} | traceId=${span.spanContext().traceId}`
+      );
+    }
+    resultCallback({ code: ExportResultCode.SUCCESS });
+  }
+  async shutdown(): Promise<void> {}
+}
+
+let resource = detectResources({
+  detectors: [envDetector, hostDetector, osDetector, processDetector],
+});
+resource = resource.merge(
+  resourceFromAttributes({ ["service.name"]: process.env.WEBSITE_SITE_NAME || "flex-concurrency-throttle" })
+);
+
+const tracerProvider = new NodeTracerProvider({
+  resource,
+  spanProcessors: [
+    new BatchSpanProcessor(new AzureMonitorTraceExporter()),
+    new SimpleSpanProcessor(new ConsoleSpanExporter()),
+  ],
+});
+tracerProvider.register();
+
+const loggerProvider = new LoggerProvider({
+  resource,
+  processors: [new BatchLogRecordProcessor(new AzureMonitorLogExporter())],
+});
+
+registerInstrumentations({
+  tracerProvider,
+  loggerProvider,
+  instrumentations: [
+    new HttpInstrumentation(),
+    new UndiciInstrumentation(),
+    new AzureFunctionsInstrumentation(),
+  ],
+});
+
+console.log(`>>> OTEL loaded in ${(performance.now() - start).toFixed(0)}ms`);

--- a/functions/flex-concurrency-throttle/test-concurrency.js
+++ b/functions/flex-concurrency-throttle/test-concurrency.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+
+/**
+ * Concurrency throttle test script.
+ *
+ * Triggers the caller function once. The caller function then generates
+ * concurrent HTTP calls to the worker function inside the same Function App.
+ * This creates clear function-to-function traces in Application Insights.
+ *
+ * Usage:
+ *   node test-concurrency.js [endpoint] [concurrency] [batches] [delayMs]
+ *
+ * Examples:
+ *   node test-concurrency.js http://localhost:7071/api/http-slow 4 3 2000
+ *   node test-concurrency.js https://azfe-concurrency-throttle.azurewebsites.net/api/http-slow 4 3 2000
+ */
+
+const BASE_URL = process.argv[2] || "http://localhost:7071/api/http-slow";
+const CONCURRENCY = parseInt(process.argv[3] || "4", 10);
+const BATCHES = parseInt(process.argv[4] || "3", 10);
+const DELAY_MS = parseInt(process.argv[5] || "2000", 10);
+
+async function triggerCaller() {
+  const runId = `run-${Date.now()}`;
+  const url = `${BASE_URL}?id=${runId}&concurrency=${CONCURRENCY}&batches=${BATCHES}&delay=${DELAY_MS}`;
+  const start = Date.now();
+
+  try {
+    const response = await fetch(url);
+    const elapsed = Date.now() - start;
+    const body = response.status === 200 ? await response.json() : { error: await response.text() };
+
+    return {
+      status: response.status,
+      elapsed,
+      body,
+      error: null,
+    };
+  } catch (error) {
+    const elapsed = Date.now() - start;
+    return {
+      status: "ERR",
+      elapsed,
+      body: null,
+      error: error.message,
+    };
+  }
+}
+
+function printWorkerResults(report) {
+  const batchResults = report.batchResults || [];
+
+  for (const batch of batchResults) {
+    console.log(`\n${"=".repeat(60)}`);
+    console.log(`BATCH ${batch.batchId}`);
+    console.log(`${"=".repeat(60)}`);
+    console.log(`  ${"ID".padEnd(22)} ${"Status".padEnd(8)} ${"Elapsed".padEnd(10)} ${"Instance".padEnd(20)} Notes`);
+    console.log(`  ${"-".repeat(60)}`);
+
+    for (const r of batch.results || []) {
+      let notes = "";
+      if (r.status === 200 && r.elapsedMs > DELAY_MS * 1.5) {
+        notes = `⚠️  QUEUED (+${r.elapsedMs - DELAY_MS}ms)`;
+      } else if (r.status === 429) {
+        notes = "🚫 THROTTLED (429)";
+      } else if (r.status === 503) {
+        notes = "🚫 UNAVAILABLE (503)";
+      } else if (r.status !== 200) {
+        notes = r.error || `HTTP ${r.status}`;
+      }
+
+      console.log(
+        `  ${String(r.id || "-").substring(0, 21).padEnd(22)} ${String(r.status).padEnd(8)} ${(`${r.elapsedMs}ms`).padEnd(10)} ${String(r.instanceId || "-").substring(0, 18).padEnd(20)} ${notes}`
+      );
+    }
+
+    console.log(`  ${"-".repeat(60)}`);
+    console.log(
+      `  Summary: ✅ ${batch.summary?.successCount || 0} success, 🚫 ${batch.summary?.throttledCount || 0} throttled, ❌ ${batch.summary?.errorCount || 0} errors`
+    );
+  }
+}
+
+async function main() {
+  console.log(`\nConcurrency Throttle Test`);
+  console.log(`========================`);
+  console.log(`Endpoint:    ${BASE_URL}`);
+  console.log(`Concurrency: ${CONCURRENCY} requests per batch`);
+  console.log(`Batches:     ${BATCHES}`);
+  console.log(`Delay:       ${DELAY_MS}ms per request`);
+  console.log(`\nhost.json expected settings:`);
+  console.log(`  maxConcurrentRequests: 6`);
+  console.log(`  maxOutstandingRequests: 10`);
+  console.log(`  dynamicThrottlesEnabled: true`);
+  console.log(`\nExpected behavior:`);
+  console.log(`  - In this demo, one outer caller request stays active while it calls /api/http-worker`);
+  console.log(`  - With 2 warm HTTP instances, a larger "fast" group is expected before queueing starts`);
+  console.log(`  - Next group is buffered/queued (longer durations)`);
+  console.log(`  - Highest-pressure tail is expected to return HTTP 429 (or 503)`);
+
+  console.log(`\nRecommended run to observe all 3 zones (immediate/queued/429):`);
+  console.log(`  node test-concurrency.js ${BASE_URL} 24 1 ${DELAY_MS}`);
+
+  console.log(`\nTriggering caller function...`);
+  const runResult = await triggerCaller();
+  if (runResult.status !== 200) {
+    console.error(`❌ Caller function failed with status ${runResult.status}:`, runResult.body?.error || runResult.error);
+    process.exit(1);
+  }
+
+  const report = runResult.body;
+  printWorkerResults(report);
+
+  // Final summary
+  console.log(`\n\n${"═".repeat(60)}`);
+  console.log(`FINAL SUMMARY`);
+  console.log(`${"═".repeat(60)}`);
+  const totals = report.summary || { successCount: 0, throttledCount: 0, errorCount: 0, totalRequests: 0 };
+  const totalRequests = totals.totalRequests || CONCURRENCY * BATCHES;
+  console.log(`Total requests sent: ${totalRequests}`);
+  console.log(`  ✅ Success:    ${totals.successCount} (${((totals.successCount / totalRequests) * 100).toFixed(1)}%)`);
+  console.log(`  🚫 Throttled:  ${totals.throttledCount} (${((totals.throttledCount / totalRequests) * 100).toFixed(1)}%)`);
+  console.log(`  ❌ Errors:     ${totals.errorCount} (${((totals.errorCount / totalRequests) * 100).toFixed(1)}%)`);
+  console.log(`  🧭 Caller duration: ${report.totalDurationMs}ms`);
+  console.log(`  🧩 Unique worker instances: ${totals.uniqueWorkerInstances || 0}`);
+  console.log(`\nConclusion:`);
+
+  if (totals.throttledCount > 0) {
+    console.log(`  ⚠️  Throttling detected! maxConcurrentRequests/maxOutstandingRequests`);
+    console.log(`     are ACTIVELY limiting throughput. This confirms the hypothesis that`);
+    console.log(`     these settings can cause request queuing/rejection in Flex Consumption.`);
+  } else if (totals.successCount === totalRequests) {
+    console.log(`  ✅ All requests succeeded — no throttling observed.`);
+    console.log(`     Either the settings don't apply as expected or instance count scaled.`);
+  }
+  console.log();
+}
+
+main().catch(console.error);

--- a/functions/flex-concurrency-throttle/tsconfig.json
+++ b/functions/flex-concurrency-throttle/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "sourceMap": false,
+    "module": "nodenext",
+    "target": "esnext",
+    "moduleResolution": "nodenext",
+    "noEmitOnError": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "types": ["node"],
+    "strict": true
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/functions/flex-per-instance-concurrency/.funcignore
+++ b/functions/flex-per-instance-concurrency/.funcignore
@@ -1,0 +1,13 @@
+*.ts
+.git*
+.vscode
+local.settings.json
+test
+getting_started.md
+node_modules/@types/
+node_modules/azure-functions-core-tools/
+node_modules/typescript/
+node_modules_build
+node_modules_build_bak
+node_modules_deploy
+node_modules_deploy_bak

--- a/functions/flex-per-instance-concurrency/README.md
+++ b/functions/flex-per-instance-concurrency/README.md
@@ -1,0 +1,66 @@
+# flex-per-instance-concurrency
+
+Tests the **Flex Consumption platform-level** `perInstanceConcurrency` setting (configured via Azure CLI, not host.json) and observes whether the platform scales out instances correctly.
+
+## Background
+
+In Flex Consumption, HTTP concurrency is controlled at the platform level:
+
+```bash
+az functionapp scale config set \
+  --resource-group $RG \
+  --name $FUNC \
+  --trigger-type http \
+  --trigger-settings perInstanceConcurrency=2
+```
+
+This tells the platform: "each instance handles max 2 HTTP requests concurrently". When more requests arrive, the platform should scale out to additional instances.
+
+## Experiment Design
+
+- **perInstanceConcurrency = 2**
+- Send 5 concurrent requests (each sleeps 3s)
+- Expected: platform scales to `ceil(5/2) = 3` instances
+- Observe: instance IDs, response times, any delays
+
+## Key Differences from `flex-concurrency-throttle`
+
+| Setting | Where | Behavior |
+|---------|-------|----------|
+| `maxConcurrentRequests` | host.json | Rejects requests (429) when limit hit |
+| `maxOutstandingRequests` | host.json | Queue size before rejection |
+| `perInstanceConcurrency` | Platform (CLI) | Triggers scale-out to more instances |
+
+## Local Test
+
+Locally, scaling won't happen (single instance), but you can verify the function works:
+
+```bash
+npm ci && npm run build
+npm start
+# In another terminal:
+node test-per-instance.js http://localhost:7071/api/http-slow 5 3000 3
+```
+
+## Azure Deploy & Test
+
+```bash
+export RESOURCE_GROUP_NAME=your-rg
+export FUNCTION_NAME=your-flex-func
+export ENDPOINT=https://your-flex-func.azurewebsites.net
+./run.sh
+```
+
+## What to Observe
+
+1. **Multiple instance IDs**: Confirms platform scaled out
+2. **Response time ~ delay (3s)**: No queuing, instances handled load
+3. **Response time >> delay**: Scaling was slow, requests queued
+4. **Cold start penalty**: First requests to new instances may be slower
+
+## Questions to Answer
+
+- How fast does Flex Consumption scale out when `perInstanceConcurrency` is exceeded?
+- Is there a visible cold-start delay on new instances?
+- With `perInstanceConcurrency=2` and 5 requests, do we actually get 3 instances?
+- What happens during scale-in — do we see the same timing issues as in QA2?

--- a/functions/flex-per-instance-concurrency/dist/src/functions/http-slow.js
+++ b/functions/flex-per-instance-concurrency/dist/src/functions/http-slow.js
@@ -1,0 +1,153 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+const functions_1 = require("@azure/functions");
+const otel = __importStar(require("@opentelemetry/api"));
+functions_1.app.http("http-slow", {
+    methods: ["GET"],
+    authLevel: "anonymous",
+    handler: async (request, context) => {
+        const startedAt = Date.now();
+        const concurrency = parseInt(request.query.get("concurrency") || "5", 10);
+        const batches = parseInt(request.query.get("batches") || "5", 10);
+        const delayMs = parseInt(request.query.get("delay") || "3000", 10);
+        const requestPrefix = request.query.get("id") || "run";
+        const instanceId = process.env.WEBSITE_INSTANCE_ID || "local";
+        const origin = new URL(request.url).origin;
+        const workerUrl = `${origin}/api/http-worker`;
+        const tracer = otel.trace.getTracer(process.env.WEBSITE_SITE_NAME || "flex-per-instance-concurrency");
+        context.log(`[caller] START concurrency=${concurrency} batches=${batches} delay=${delayMs}ms worker=${workerUrl} instance=${instanceId}`);
+        const result = await tracer.startActiveSpan("orchestrateWorkerBatches", {
+            kind: otel.SpanKind.INTERNAL,
+            attributes: {
+                "request.concurrency": concurrency,
+                "request.batches": batches,
+                "request.delay_ms": delayMs,
+                "instance.id": instanceId,
+                "concurrency.test": "perInstanceConcurrency",
+                "function.role": "caller",
+            },
+        }, async (span) => {
+            const batchResults = [];
+            let totalSuccess = 0;
+            let totalThrottled = 0;
+            let totalErrors = 0;
+            const workerInstances = new Set();
+            try {
+                for (let batch = 1; batch <= batches; batch++) {
+                    const batchStart = Date.now();
+                    span.addEvent("batch.start", { batch_id: batch, concurrency });
+                    context.log(`[caller] BATCH ${batch} START concurrency=${concurrency}`);
+                    const requests = Array.from({ length: concurrency }, (_, idx) => {
+                        const reqId = `${requestPrefix}-b${batch}-r${idx + 1}`;
+                        const url = `${workerUrl}?id=${encodeURIComponent(reqId)}&batch=${batch}&delay=${delayMs}`;
+                        const start = Date.now();
+                        return fetch(url)
+                            .then(async (response) => {
+                            const elapsedMs = Date.now() - start;
+                            if (response.status === 200) {
+                                const body = (await response.json());
+                                if (body.instanceId) {
+                                    workerInstances.add(body.instanceId);
+                                }
+                                return { id: reqId, status: 200, elapsedMs, instanceId: body.instanceId };
+                            }
+                            return { id: reqId, status: response.status, elapsedMs, error: `HTTP ${response.status}` };
+                        })
+                            .catch((error) => {
+                            const elapsedMs = Date.now() - start;
+                            return { id: reqId, status: "ERR", elapsedMs, error: error.message };
+                        });
+                    });
+                    const settled = await Promise.all(requests);
+                    const batchSuccess = settled.filter((r) => r.status === 200).length;
+                    const batchThrottled = settled.filter((r) => r.status === 429 || r.status === 503).length;
+                    const batchErrors = settled.length - batchSuccess - batchThrottled;
+                    totalSuccess += batchSuccess;
+                    totalThrottled += batchThrottled;
+                    totalErrors += batchErrors;
+                    span.addEvent("batch.end", {
+                        batch_id: batch,
+                        duration_ms: Date.now() - batchStart,
+                        success_count: batchSuccess,
+                        throttled_count: batchThrottled,
+                        error_count: batchErrors,
+                    });
+                    context.log(`[caller] BATCH ${batch} END success=${batchSuccess} throttled=${batchThrottled} errors=${batchErrors} duration=${Date.now() - batchStart}ms`);
+                    batchResults.push({
+                        batchId: batch,
+                        summary: { successCount: batchSuccess, throttledCount: batchThrottled, errorCount: batchErrors },
+                        results: settled,
+                    });
+                }
+                const totalDurationMs = Date.now() - startedAt;
+                span.setAttribute("total.duration_ms", totalDurationMs);
+                span.setAttribute("summary.success_count", totalSuccess);
+                span.setAttribute("summary.throttled_count", totalThrottled);
+                span.setAttribute("summary.error_count", totalErrors);
+                span.setAttribute("summary.unique_worker_instances", workerInstances.size);
+                context.log(`[caller] END totalDuration=${totalDurationMs}ms success=${totalSuccess} throttled=${totalThrottled} errors=${totalErrors} workerInstances=${workerInstances.size}`);
+                return {
+                    status: 200,
+                    jsonBody: {
+                        startTime: new Date(startedAt).toISOString(),
+                        endTime: new Date().toISOString(),
+                        totalDurationMs,
+                        scenario: {
+                            concurrency,
+                            batches,
+                            delayMs,
+                            callerInstanceId: instanceId,
+                            workerUrl,
+                        },
+                        summary: {
+                            totalRequests: concurrency * batches,
+                            successCount: totalSuccess,
+                            throttledCount: totalThrottled,
+                            errorCount: totalErrors,
+                            uniqueWorkerInstances: workerInstances.size,
+                        },
+                        batchResults,
+                        callerTraceId: span.spanContext().traceId,
+                    },
+                };
+            }
+            finally {
+                span.end();
+            }
+        });
+        return result;
+    },
+});

--- a/functions/flex-per-instance-concurrency/dist/src/functions/http-worker.js
+++ b/functions/flex-per-instance-concurrency/dist/src/functions/http-worker.js
@@ -1,0 +1,87 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+const functions_1 = require("@azure/functions");
+const promises_1 = require("timers/promises");
+const otel = __importStar(require("@opentelemetry/api"));
+functions_1.app.http("http-worker", {
+    methods: ["GET"],
+    authLevel: "anonymous",
+    handler: async (request, context) => {
+        const startTime = Date.now();
+        const delayMs = parseInt(request.query.get("delay") || "3000", 10);
+        const requestId = request.query.get("id") || "unknown";
+        const batchId = parseInt(request.query.get("batch") || "0", 10);
+        const instanceId = process.env.WEBSITE_INSTANCE_ID || "local";
+        const tracer = otel.trace.getTracer(process.env.WEBSITE_SITE_NAME || "flex-per-instance-concurrency");
+        return tracer.startActiveSpan("workerSleep", {
+            kind: otel.SpanKind.INTERNAL,
+            attributes: {
+                "request.id": requestId,
+                "batch.id": batchId,
+                "request.delay_ms": delayMs,
+                "instance.id": instanceId,
+                "function.role": "worker",
+            },
+        }, async (span) => {
+            try {
+                span.addEvent("worker.start", { delay_ms: delayMs, batch_id: batchId });
+                context.log(`[worker][${requestId}] START batch=${batchId} delay=${delayMs}ms instance=${instanceId}`);
+                await (0, promises_1.setTimeout)(delayMs);
+                const duration = Date.now() - startTime;
+                span.addEvent("worker.end", { duration_ms: duration });
+                span.setAttribute("request.actual_duration_ms", duration);
+                context.log(`[worker][${requestId}] END batch=${batchId} duration=${duration}ms instance=${instanceId}`);
+                return {
+                    status: 200,
+                    jsonBody: {
+                        requestId,
+                        batchId,
+                        startTime: new Date(startTime).toISOString(),
+                        endTime: new Date().toISOString(),
+                        durationMs: duration,
+                        delayMs,
+                        overheadMs: duration - delayMs,
+                        instanceId,
+                        traceId: span.spanContext().traceId,
+                    },
+                };
+            }
+            finally {
+                span.end();
+            }
+        });
+    },
+});

--- a/functions/flex-per-instance-concurrency/dist/src/opentelemetry.js
+++ b/functions/flex-per-instance-concurrency/dist/src/opentelemetry.js
@@ -1,0 +1,51 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ConsoleSpanExporter = void 0;
+console.log(">>> OTEL loading");
+const start = performance.now();
+const functions_opentelemetry_instrumentation_1 = require("@azure/functions-opentelemetry-instrumentation");
+const monitor_opentelemetry_exporter_1 = require("@azure/monitor-opentelemetry-exporter");
+const instrumentation_http_1 = require("@opentelemetry/instrumentation-http");
+const instrumentation_undici_1 = require("@opentelemetry/instrumentation-undici");
+const instrumentation_1 = require("@opentelemetry/instrumentation");
+const resources_1 = require("@opentelemetry/resources");
+const sdk_logs_1 = require("@opentelemetry/sdk-logs");
+const sdk_trace_node_1 = require("@opentelemetry/sdk-trace-node");
+const core_1 = require("@opentelemetry/core");
+// Console exporter for debugging — prints spans to stdout
+class ConsoleSpanExporter {
+    export(spans, resultCallback) {
+        for (const span of spans) {
+            console.log(`[SPAN] ${span.name} | duration=${(span.duration[0] * 1000 + span.duration[1] / 1e6).toFixed(1)}ms | status=${span.status.code} | traceId=${span.spanContext().traceId}`);
+        }
+        resultCallback({ code: core_1.ExportResultCode.SUCCESS });
+    }
+    async shutdown() { }
+}
+exports.ConsoleSpanExporter = ConsoleSpanExporter;
+let resource = (0, resources_1.detectResources)({
+    detectors: [resources_1.envDetector, resources_1.hostDetector, resources_1.osDetector, resources_1.processDetector],
+});
+resource = resource.merge((0, resources_1.resourceFromAttributes)({ ["service.name"]: process.env.WEBSITE_SITE_NAME || "flex-per-instance-concurrency" }));
+const tracerProvider = new sdk_trace_node_1.NodeTracerProvider({
+    resource,
+    spanProcessors: [
+        new sdk_trace_node_1.BatchSpanProcessor(new monitor_opentelemetry_exporter_1.AzureMonitorTraceExporter()),
+        new sdk_trace_node_1.SimpleSpanProcessor(new ConsoleSpanExporter()),
+    ],
+});
+tracerProvider.register();
+const loggerProvider = new sdk_logs_1.LoggerProvider({
+    resource,
+    processors: [new sdk_logs_1.BatchLogRecordProcessor(new monitor_opentelemetry_exporter_1.AzureMonitorLogExporter())],
+});
+(0, instrumentation_1.registerInstrumentations)({
+    tracerProvider,
+    loggerProvider,
+    instrumentations: [
+        new instrumentation_http_1.HttpInstrumentation(),
+        new instrumentation_undici_1.UndiciInstrumentation(),
+        new functions_opentelemetry_instrumentation_1.AzureFunctionsInstrumentation(),
+    ],
+});
+console.log(`>>> OTEL loaded in ${(performance.now() - start).toFixed(0)}ms`);

--- a/functions/flex-per-instance-concurrency/host.json
+++ b/functions/flex-per-instance-concurrency/host.json
@@ -1,0 +1,25 @@
+{
+  "version": "2.0",
+  "telemetryMode": "OpenTelemetry",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": false
+      }
+    },
+    "logLevel": {
+      "default": "Information",
+      "Host.Results": "Information",
+      "Function": "Information"
+    }
+  },
+  "extensions": {
+    "http": {
+      "routePrefix": "api"
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/functions/flex-per-instance-concurrency/package-lock.json
+++ b/functions/flex-per-instance-concurrency/package-lock.json
@@ -1,0 +1,1259 @@
+{
+  "name": "@msft-azure-test-functions/flex-per-instance-concurrency",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@msft-azure-test-functions/flex-per-instance-concurrency",
+      "version": "1.0.0",
+      "dependencies": {
+        "@azure/functions": "4.8.0",
+        "@azure/functions-opentelemetry-instrumentation": "0.2.0",
+        "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.32",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/api-logs": "0.205.0",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/instrumentation": "0.205.0",
+        "@opentelemetry/instrumentation-http": "0.205.0",
+        "@opentelemetry/instrumentation-undici": "0.16.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/sdk-logs": "0.205.0",
+        "@opentelemetry/sdk-trace-node": "2.1.0"
+      },
+      "devDependencies": {
+        "@types/node": "22.18.0",
+        "azure-functions-core-tools": "4.2.2",
+        "typescript": "5.9.2"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.2.tgz",
+      "integrity": "sha512-1D2LpsU7y9xrqKjdIbsB7PlrRePw0xsVV8p+AKTlzITrWmscajryfJCdDJB/oGwvDI5HmRo04eMMADB67uwAwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.24.0.tgz",
+      "integrity": "sha512-PpLsoDQ3AMmKZ0VU+0GrmqMxgp/sExjlVm4R+nLWngeoEGAzOIPVifaxKGU5gMv+nWELUoHfvrolWD+ZS/nFJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/functions": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.0.tgz",
+      "integrity": "sha512-LNtl3xZNE40vE7+SIST+GYQX5cnnI1M65fXPi26l9XCdPakuQrz54lHv+qQQt1GG5JbqLfQk75iM7A6Y9O+2dQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.7.0",
+        "long": "^4.0.0",
+        "undici": "^5.29.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@azure/functions-opentelemetry-instrumentation": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/functions-opentelemetry-instrumentation/-/functions-opentelemetry-instrumentation-0.2.0.tgz",
+      "integrity": "sha512-IvgsbgfIeuR5Q5IDm2ZgiW9b4PumMHZF0UH99zbKlq+YoaMZWucU2rpsUhFugoaPCtsZtEbKA17prv3+URbI9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.52.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/monitor-opentelemetry-exporter": {
+      "version": "1.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@azure/monitor-opentelemetry-exporter/-/monitor-opentelemetry-exporter-1.0.0-beta.32.tgz",
+      "integrity": "sha512-Tk5Tv8KwHhKCQlXET/7ZLtjBv1Zi4lmPTadKTQ9KCURRJWdt+6hu5ze52Tlp2pVeg3mg+MRQ9vhWvVNXMZAp/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.19.0",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.200.0",
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/resources": "^2.0.0",
+        "@opentelemetry/sdk-logs": "^0.200.0",
+        "@opentelemetry/sdk-metrics": "^2.0.0",
+        "@opentelemetry/sdk-trace-base": "^2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.32.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/monitor-opentelemetry-exporter/node_modules/@opentelemetry/api-logs": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.200.0.tgz",
+      "integrity": "sha512-IKJBQxh91qJ+3ssRly5hYEJ8NDHu9oY/B1PXVSCWf7zytmYO9RNLB0Ox9XQ/fJ8m6gY6Q6NtBWlmXfaXt5Uc4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@azure/monitor-opentelemetry-exporter/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@azure/monitor-opentelemetry-exporter/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@azure/monitor-opentelemetry-exporter/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.200.0.tgz",
+      "integrity": "sha512-VZG870063NLfObmQQNtCVcdXXLzI3vOjjrRENmU37HYiPFa0ZXpXVDsTD02Nh3AT3xYJzQaWKl2X2lQ2l7TWJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.200.0",
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.205.0.tgz",
+      "integrity": "sha512-wBlPk1nFB37Hsm+3Qy73yQSobVn28F4isnWIBvKpd5IUH/eat8bwcL02H9yzmHyyPmukeccSl2mbN5sDQZYnPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.1.0.tgz",
+      "integrity": "sha512-zOyetmZppnwTyPrt4S7jMfXiSX9yyfF0hxlA8B5oo2TtKl+/RGCy7fi4DrBfIf3lCPrkKsRBWZZD7RFojK7FDg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.205.0.tgz",
+      "integrity": "sha512-cgvm7tvQdu9Qo7VurJP84wJ7ZV9F6WqDDGZpUc6rUEXwjV7/bXWs0kaYp9v+1Vh1+3TZCD3i6j/lUBcPhu8NhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.205.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.205.0.tgz",
+      "integrity": "sha512-6fOgRlV7ypBuEzCQP7vXkLQxz3UL1FhE24rAlMRbwGvPAnZLvutcG/fq9FI/n+VU23dOpYexocYsXCf5oy/AXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/instrumentation": "0.205.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0",
+        "forwarded-parse": "2.1.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-undici": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.16.0.tgz",
+      "integrity": "sha512-sky42QpDmsHbrmE02sCEk7kdug2uTB4w5OwLpfHKom/5vbzTJZDoaM68YpCq0vTQ9QwL/DIDGwjdaTcU+XXCxQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.205.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
+      "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.205.0.tgz",
+      "integrity": "sha512-nyqhNQ6eEzPWQU60Nc7+A5LIq8fz3UeIzdEVBQYefB4+msJZ2vuVtRuk9KxPMw1uHoHDtYEwkr2Ct0iG29jU8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.205.0",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.9.0.tgz",
+      "integrity": "sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
+      "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.1.0.tgz",
+      "integrity": "sha512-SvVlBFc/jI96u/mmlKm86n9BbTCbQ35nsPoOohqJX6DXH92K0kTe73zGY5r8xoI1QkjR9PizszVJLzMC966y9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.1.0",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/sdk-trace-base": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz",
+      "integrity": "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace/node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace/node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.18.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.0.tgz",
+      "integrity": "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.6.tgz",
+      "integrity": "sha512-jIXhD0eWQ1JA6ln/5Dltyx22UxWNrw0hZmhy2rlv6m6KgF7kplHx3g0fzi09lNmTJQRR91OlemYp3xFnvDK9og==",
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/azure-functions-core-tools": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/azure-functions-core-tools/-/azure-functions-core-tools-4.2.2.tgz",
+      "integrity": "sha512-TxafmfFZCOdv9hoU29W/IPEiwlwTT3jj4ZnM58DttG+LLxPz1Xc2+afSzQ502WpemHI9wvGLYXb55KDGCwKKRw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "hasShrinkwrap": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "chalk": "3.0.0",
+        "extract-zip": "^2.0.1",
+        "https-proxy-agent": "5.0.1",
+        "progress": "2.0.3",
+        "rimraf": "4.4.1"
+      },
+      "bin": {
+        "azfun": "lib/main.js",
+        "azurefunctions": "lib/main.js",
+        "func": "lib/main.js"
+      },
+      "engines": {
+        "node": ">=6.9.1"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
+    "node_modules/azure-functions-core-tools/node_modules/@types/node": {
+      "version": "18.15.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/azure-functions-core-tools/node_modules/@types/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/ansi-styles": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.0.tgz",
+      "integrity": "sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==",
+      "dev": true,
+      "dependencies": {
+        "@types/color-name": "^1.1.1",
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/azure-functions-core-tools/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/azure-functions-core-tools/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/azure-functions-core-tools/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/glob": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/azure-functions-core-tools/node_modules/minimatch": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/azure-functions-core-tools/node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
+    },
+    "node_modules/azure-functions-core-tools/node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/rimraf": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
+      "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^9.2.0"
+      },
+      "bin": {
+        "rimraf": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/supports-color": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/azure-functions-core-tools/node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "node_modules/azure-functions-core-tools/node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/forwarded-parse": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+      "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
+      "license": "MIT"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
+      "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+      "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/functions/flex-per-instance-concurrency/package.json
+++ b/functions/flex-per-instance-concurrency/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@msft-azure-test-functions/flex-per-instance-concurrency",
+  "version": "1.0.0",
+  "main": "dist/src/functions/*.js",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "start": "func start"
+  },
+  "dependencies": {
+    "@azure/functions": "4.8.0",
+    "@azure/functions-opentelemetry-instrumentation": "0.2.0",
+    "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.32",
+    "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/api-logs": "0.205.0",
+    "@opentelemetry/core": "2.1.0",
+    "@opentelemetry/instrumentation": "0.205.0",
+    "@opentelemetry/instrumentation-http": "0.205.0",
+    "@opentelemetry/instrumentation-undici": "0.16.0",
+    "@opentelemetry/resources": "2.1.0",
+    "@opentelemetry/sdk-logs": "0.205.0",
+    "@opentelemetry/sdk-trace-node": "2.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "22.18.0",
+    "azure-functions-core-tools": "4.2.2",
+    "typescript": "5.9.2"
+  },
+  "overrides": {
+    "@azure/functions-opentelemetry-instrumentation": {
+      "@opentelemetry/api-logs": "0.205.0",
+      "@opentelemetry/instrumentation": "0.205.0"
+    }
+  }
+}

--- a/functions/flex-per-instance-concurrency/run.sh
+++ b/functions/flex-per-instance-concurrency/run.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+set -euo pipefail
+
+# Deploy and test flex-per-instance-concurrency experiment
+#
+# This tests the Flex Consumption perInstanceConcurrency platform setting.
+# Unlike maxConcurrentRequests (host.json), this is a platform-level setting
+# configured via Azure CLI that controls how many HTTP requests each instance
+# handles concurrently, and triggers scale-out when exceeded.
+#
+# Optional env vars (all have defaults):
+#   SUBSCRIPTION_ID   - Azure subscription
+#   RESOURCE_GROUP_NAME - Azure resource group
+#   FUNCTION_NAME     - Function app name (Flex Consumption)
+#   REGION            - Azure region
+#   STORAGE_ACCOUNT   - Storage account name (auto-discovered if omitted)
+#   REFERENCE_FUNCTION_NAME - Existing app from which to reuse AI connection string
+#   APIM_ENDPOINT     - Existing APIM base URL (preferred for testing via APIM)
+#   FUNCTION_ENDPOINT - Explicit function endpoint override
+
+SUBSCRIPTION_ID="${SUBSCRIPTION_ID:-0ebbefb8-987e-4fcd-bbbc-41d704f2d586}"
+RESOURCE_GROUP_NAME="${RESOURCE_GROUP_NAME:-playground-kamil}"
+FUNCTION_NAME="${FUNCTION_NAME:-azfe-per-instance-conc}"
+REGION="${REGION:-westeurope}"
+STORAGE_ACCOUNT="${STORAGE_ACCOUNT:-}"
+REFERENCE_FUNCTION_NAME="${REFERENCE_FUNCTION_NAME:-azure-test-otel}"
+APIM_ENDPOINT="${APIM_ENDPOINT:-}"
+FUNCTION_ENDPOINT="${FUNCTION_ENDPOINT:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "Using subscription: ${SUBSCRIPTION_ID}"
+az account set --subscription "$SUBSCRIPTION_ID"
+
+resolve_storage_account() {
+  if [[ -n "$STORAGE_ACCOUNT" ]]; then
+    return 0
+  fi
+
+  STORAGE_ACCOUNT="$(az storage account list \
+    --resource-group "$RESOURCE_GROUP_NAME" \
+    --query "[?kind=='StorageV2' || kind=='Storage'].name | [0]" \
+    -o tsv 2>/dev/null || true)"
+
+  if [[ -z "$STORAGE_ACCOUNT" ]]; then
+    echo "Error: No storage account found in ${RESOURCE_GROUP_NAME}."
+    echo "Set STORAGE_ACCOUNT explicitly, or create one first."
+    exit 1
+  fi
+
+  echo "Auto-discovered storage account: ${STORAGE_ACCOUNT}"
+}
+
+ensure_function_app_exists() {
+  if az functionapp show --resource-group "$RESOURCE_GROUP_NAME" --name "$FUNCTION_NAME" >/dev/null 2>&1; then
+    echo "Function app ${FUNCTION_NAME} already exists, reusing it."
+    return 0
+  fi
+
+  resolve_storage_account
+  echo "Creating Function App ${FUNCTION_NAME} in ${RESOURCE_GROUP_NAME}..."
+  az functionapp create \
+    --resource-group "$RESOURCE_GROUP_NAME" \
+    --name "$FUNCTION_NAME" \
+    --storage-account "$STORAGE_ACCOUNT" \
+    --flexconsumption-location "$REGION" \
+    --runtime node \
+    --runtime-version 22
+}
+
+resolve_app_insights_connection_string() {
+  local existing_value
+
+  existing_value="$(az functionapp config appsettings list \
+    --resource-group "$RESOURCE_GROUP_NAME" \
+    --name "$FUNCTION_NAME" \
+    --query "[?name=='APPLICATIONINSIGHTS_CONNECTION_STRING'].value | [0]" \
+    -o tsv 2>/dev/null || true)"
+
+  if [[ -n "$existing_value" ]]; then
+    printf '%s' "$existing_value"
+    return 0
+  fi
+
+  az functionapp config appsettings list \
+    --resource-group "$RESOURCE_GROUP_NAME" \
+    --name "$REFERENCE_FUNCTION_NAME" \
+    --query "[?name=='APPLICATIONINSIGHTS_CONNECTION_STRING'].value | [0]" \
+    -o tsv 2>/dev/null || true
+}
+
+echo "=== flex-per-instance-concurrency ==="
+echo ""
+
+# Build
+echo "Building..."
+if [[ ! -d node_modules ]]; then
+  npm install --no-audit --fund=false
+else
+  echo "Using existing node_modules"
+fi
+npm run build
+
+# Deploy & configure
+ensure_function_app_exists
+echo ""
+echo "Setting OTEL preload app setting..."
+ai_connection_string="$(resolve_app_insights_connection_string)"
+if [[ -n "$ai_connection_string" ]]; then
+  az functionapp config appsettings set \
+    --resource-group "$RESOURCE_GROUP_NAME" \
+    --name "$FUNCTION_NAME" \
+    --settings \
+    "languageWorkers__node__arguments=--require ./dist/src/opentelemetry.js" \
+    "APPLICATIONINSIGHTS_CONNECTION_STRING=$ai_connection_string" >/dev/null
+else
+  echo "Warning: could not resolve APPLICATIONINSIGHTS_CONNECTION_STRING."
+  az functionapp config appsettings set \
+    --resource-group "$RESOURCE_GROUP_NAME" \
+    --name "$FUNCTION_NAME" \
+    --settings \
+    "languageWorkers__node__arguments=--require ./dist/src/opentelemetry.js" >/dev/null
+fi
+
+echo ""
+echo "Waiting 10s for settings to propagate..."
+sleep 10
+
+echo "Deploying to ${FUNCTION_NAME} in ${RESOURCE_GROUP_NAME}..."
+func azure functionapp publish "$FUNCTION_NAME" --javascript
+
+echo ""
+echo "Configuring perInstanceConcurrency=2..."
+az functionapp scale config set \
+  --resource-group "$RESOURCE_GROUP_NAME" \
+  --name "$FUNCTION_NAME" \
+  --trigger-type http \
+  --trigger-settings perInstanceConcurrency=2
+
+echo ""
+echo "Current scale config:"
+az functionapp scale config show \
+  --resource-group "$RESOURCE_GROUP_NAME" \
+  --name "$FUNCTION_NAME" \
+  --output table
+
+echo ""
+echo "Waiting 15s for config to propagate..."
+sleep 15
+
+# Test
+if [[ -n "$APIM_ENDPOINT" ]]; then
+  FUNCTION_ENDPOINT="$APIM_ENDPOINT"
+fi
+
+if [[ -z "$FUNCTION_ENDPOINT" ]]; then
+  host_name="$(az functionapp show \
+    --name "$FUNCTION_NAME" \
+    --resource-group "$RESOURCE_GROUP_NAME" \
+    --query "properties.defaultHostName" -o tsv)"
+  FUNCTION_ENDPOINT="https://${host_name}"
+fi
+
+echo ""
+echo "Testing against: ${FUNCTION_ENDPOINT}/api/http-slow"
+echo ""
+
+# Test 1: Within limit (2 requests, perInstanceConcurrency=2)
+echo "--- Test 1: 2 concurrent requests (within single instance limit) ---"
+node test-per-instance.js "${FUNCTION_ENDPOINT}/api/http-slow" 2 3000 2
+
+# Test 2: Exceed limit (5 requests, should need 3 instances)
+echo ""
+echo "--- Test 2: 5 concurrent requests (should trigger scale-out to 3 instances) ---"
+node test-per-instance.js "${FUNCTION_ENDPOINT}/api/http-slow" 5 3000 5
+
+# Test 3: Higher load (8 requests, should need 4 instances)
+echo ""
+echo "--- Test 3: 8 concurrent requests (should trigger scale-out to 4 instances) ---"
+node test-per-instance.js "${FUNCTION_ENDPOINT}/api/http-slow" 8 3000 3

--- a/functions/flex-per-instance-concurrency/src/functions/http-slow.ts
+++ b/functions/flex-per-instance-concurrency/src/functions/http-slow.ts
@@ -1,0 +1,145 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
+import * as otel from "@opentelemetry/api";
+
+app.http("http-slow", {
+  methods: ["GET"],
+  authLevel: "anonymous",
+  handler: async (request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> => {
+    const startedAt = Date.now();
+    const concurrency = parseInt(request.query.get("concurrency") || "5", 10);
+    const batches = parseInt(request.query.get("batches") || "5", 10);
+    const delayMs = parseInt(request.query.get("delay") || "3000", 10);
+    const requestPrefix = request.query.get("id") || "run";
+    const instanceId = process.env.WEBSITE_INSTANCE_ID || "local";
+    const origin = new URL(request.url).origin;
+    const workerUrl = `${origin}/api/http-worker`;
+    const tracer = otel.trace.getTracer(process.env.WEBSITE_SITE_NAME || "flex-per-instance-concurrency");
+
+    context.log(`[caller] START concurrency=${concurrency} batches=${batches} delay=${delayMs}ms worker=${workerUrl} instance=${instanceId}`);
+
+    const result = await tracer.startActiveSpan(
+      "orchestrateWorkerBatches",
+      {
+        kind: otel.SpanKind.INTERNAL,
+        attributes: {
+          "request.concurrency": concurrency,
+          "request.batches": batches,
+          "request.delay_ms": delayMs,
+          "instance.id": instanceId,
+          "concurrency.test": "perInstanceConcurrency",
+          "function.role": "caller",
+        },
+      },
+      async (span) => {
+        const batchResults: Array<{
+          batchId: number;
+          summary: { successCount: number; throttledCount: number; errorCount: number };
+          results: Array<{ id: string; status: number | string; elapsedMs: number; instanceId?: string; error?: string }>;
+        }> = [];
+
+        let totalSuccess = 0;
+        let totalThrottled = 0;
+        let totalErrors = 0;
+        const workerInstances = new Set<string>();
+
+        try {
+          for (let batch = 1; batch <= batches; batch++) {
+            const batchStart = Date.now();
+            span.addEvent("batch.start", { batch_id: batch, concurrency });
+            context.log(`[caller] BATCH ${batch} START concurrency=${concurrency}`);
+
+            const requests = Array.from({ length: concurrency }, (_, idx) => {
+              const reqId = `${requestPrefix}-b${batch}-r${idx + 1}`;
+              const url = `${workerUrl}?id=${encodeURIComponent(reqId)}&batch=${batch}&delay=${delayMs}`;
+              const start = Date.now();
+
+              return fetch(url)
+                .then(async (response) => {
+                  const elapsedMs = Date.now() - start;
+                  if (response.status === 200) {
+                    const body = (await response.json()) as { instanceId?: string };
+                    if (body.instanceId) {
+                      workerInstances.add(body.instanceId);
+                    }
+                    return { id: reqId, status: 200, elapsedMs, instanceId: body.instanceId };
+                  }
+                  return { id: reqId, status: response.status, elapsedMs, error: `HTTP ${response.status}` };
+                })
+                .catch((error: Error) => {
+                  const elapsedMs = Date.now() - start;
+                  return { id: reqId, status: "ERR", elapsedMs, error: error.message };
+                });
+            });
+
+            const settled = await Promise.all(requests);
+            const batchSuccess = settled.filter((r) => r.status === 200).length;
+            const batchThrottled = settled.filter((r) => r.status === 429 || r.status === 503).length;
+            const batchErrors = settled.length - batchSuccess - batchThrottled;
+
+            totalSuccess += batchSuccess;
+            totalThrottled += batchThrottled;
+            totalErrors += batchErrors;
+
+            span.addEvent("batch.end", {
+              batch_id: batch,
+              duration_ms: Date.now() - batchStart,
+              success_count: batchSuccess,
+              throttled_count: batchThrottled,
+              error_count: batchErrors,
+            });
+
+            context.log(
+              `[caller] BATCH ${batch} END success=${batchSuccess} throttled=${batchThrottled} errors=${batchErrors} duration=${Date.now() - batchStart}ms`
+            );
+
+            batchResults.push({
+              batchId: batch,
+              summary: { successCount: batchSuccess, throttledCount: batchThrottled, errorCount: batchErrors },
+              results: settled,
+            });
+          }
+
+          const totalDurationMs = Date.now() - startedAt;
+          span.setAttribute("total.duration_ms", totalDurationMs);
+          span.setAttribute("summary.success_count", totalSuccess);
+          span.setAttribute("summary.throttled_count", totalThrottled);
+          span.setAttribute("summary.error_count", totalErrors);
+          span.setAttribute("summary.unique_worker_instances", workerInstances.size);
+
+          context.log(
+            `[caller] END totalDuration=${totalDurationMs}ms success=${totalSuccess} throttled=${totalThrottled} errors=${totalErrors} workerInstances=${workerInstances.size}`
+          );
+
+          return {
+            status: 200 as const,
+            jsonBody: {
+              startTime: new Date(startedAt).toISOString(),
+              endTime: new Date().toISOString(),
+              totalDurationMs,
+              scenario: {
+                concurrency,
+                batches,
+                delayMs,
+                callerInstanceId: instanceId,
+                workerUrl,
+              },
+              summary: {
+                totalRequests: concurrency * batches,
+                successCount: totalSuccess,
+                throttledCount: totalThrottled,
+                errorCount: totalErrors,
+                uniqueWorkerInstances: workerInstances.size,
+              },
+              batchResults,
+              callerTraceId: span.spanContext().traceId,
+            },
+          };
+        } finally {
+          span.end();
+        }
+      }
+    );
+
+    return result;
+  },
+});

--- a/functions/flex-per-instance-concurrency/src/functions/http-worker.ts
+++ b/functions/flex-per-instance-concurrency/src/functions/http-worker.ts
@@ -1,0 +1,61 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
+import { setTimeout } from "timers/promises";
+import * as otel from "@opentelemetry/api";
+
+app.http("http-worker", {
+  methods: ["GET"],
+  authLevel: "anonymous",
+  handler: async (request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> => {
+    const startTime = Date.now();
+    const delayMs = parseInt(request.query.get("delay") || "3000", 10);
+    const requestId = request.query.get("id") || "unknown";
+    const batchId = parseInt(request.query.get("batch") || "0", 10);
+    const instanceId = process.env.WEBSITE_INSTANCE_ID || "local";
+    const tracer = otel.trace.getTracer(process.env.WEBSITE_SITE_NAME || "flex-per-instance-concurrency");
+
+    return tracer.startActiveSpan(
+      "workerSleep",
+      {
+        kind: otel.SpanKind.INTERNAL,
+        attributes: {
+          "request.id": requestId,
+          "batch.id": batchId,
+          "request.delay_ms": delayMs,
+          "instance.id": instanceId,
+          "function.role": "worker",
+        },
+      },
+      async (span) => {
+        try {
+          span.addEvent("worker.start", { delay_ms: delayMs, batch_id: batchId });
+          context.log(`[worker][${requestId}] START batch=${batchId} delay=${delayMs}ms instance=${instanceId}`);
+
+          await setTimeout(delayMs);
+
+          const duration = Date.now() - startTime;
+          span.addEvent("worker.end", { duration_ms: duration });
+          span.setAttribute("request.actual_duration_ms", duration);
+
+          context.log(`[worker][${requestId}] END batch=${batchId} duration=${duration}ms instance=${instanceId}`);
+
+          return {
+            status: 200,
+            jsonBody: {
+              requestId,
+              batchId,
+              startTime: new Date(startTime).toISOString(),
+              endTime: new Date().toISOString(),
+              durationMs: duration,
+              delayMs,
+              overheadMs: duration - delayMs,
+              instanceId,
+              traceId: span.spanContext().traceId,
+            },
+          };
+        } finally {
+          span.end();
+        }
+      }
+    );
+  },
+});

--- a/functions/flex-per-instance-concurrency/src/opentelemetry.ts
+++ b/functions/flex-per-instance-concurrency/src/opentelemetry.ts
@@ -1,0 +1,75 @@
+console.log(">>> OTEL loading");
+const start = performance.now();
+
+import { AzureFunctionsInstrumentation } from "@azure/functions-opentelemetry-instrumentation";
+import {
+  AzureMonitorLogExporter,
+  AzureMonitorTraceExporter,
+} from "@azure/monitor-opentelemetry-exporter";
+import { HttpInstrumentation } from "@opentelemetry/instrumentation-http";
+import { UndiciInstrumentation } from "@opentelemetry/instrumentation-undici";
+import { registerInstrumentations } from "@opentelemetry/instrumentation";
+import {
+  detectResources,
+  envDetector,
+  hostDetector,
+  osDetector,
+  processDetector,
+  resourceFromAttributes,
+} from "@opentelemetry/resources";
+import { LoggerProvider, BatchLogRecordProcessor } from "@opentelemetry/sdk-logs";
+import {
+  NodeTracerProvider,
+  BatchSpanProcessor,
+  SimpleSpanProcessor,
+  SpanExporter,
+  ReadableSpan,
+} from "@opentelemetry/sdk-trace-node";
+import { ExportResultCode } from "@opentelemetry/core";
+import type { ExportResult } from "@opentelemetry/core";
+
+// Console exporter for debugging — prints spans to stdout
+export class ConsoleSpanExporter implements SpanExporter {
+  export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
+    for (const span of spans) {
+      console.log(
+        `[SPAN] ${span.name} | duration=${(span.duration[0] * 1000 + span.duration[1] / 1e6).toFixed(1)}ms | status=${span.status.code} | traceId=${span.spanContext().traceId}`
+      );
+    }
+    resultCallback({ code: ExportResultCode.SUCCESS });
+  }
+  async shutdown(): Promise<void> {}
+}
+
+let resource = detectResources({
+  detectors: [envDetector, hostDetector, osDetector, processDetector],
+});
+resource = resource.merge(
+  resourceFromAttributes({ ["service.name"]: process.env.WEBSITE_SITE_NAME || "flex-per-instance-concurrency" })
+);
+
+const tracerProvider = new NodeTracerProvider({
+  resource,
+  spanProcessors: [
+    new BatchSpanProcessor(new AzureMonitorTraceExporter()),
+    new SimpleSpanProcessor(new ConsoleSpanExporter()),
+  ],
+});
+tracerProvider.register();
+
+const loggerProvider = new LoggerProvider({
+  resource,
+  processors: [new BatchLogRecordProcessor(new AzureMonitorLogExporter())],
+});
+
+registerInstrumentations({
+  tracerProvider,
+  loggerProvider,
+  instrumentations: [
+    new HttpInstrumentation(),
+    new UndiciInstrumentation(),
+    new AzureFunctionsInstrumentation(),
+  ],
+});
+
+console.log(`>>> OTEL loaded in ${(performance.now() - start).toFixed(0)}ms`);

--- a/functions/flex-per-instance-concurrency/test-per-instance.js
+++ b/functions/flex-per-instance-concurrency/test-per-instance.js
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+/**
+ * Per-instance concurrency test script.
+ *
+ * Triggers the caller function once. The caller then generates concurrent
+ * HTTP calls to the worker function in the same app.
+ *
+ * Usage:
+ *   node test-per-instance.js [endpoint] [concurrency] [delayMs] [batches]
+ */
+
+const BASE_URL = process.argv[2] || "http://localhost:7071/api/http-slow";
+const CONCURRENCY = parseInt(process.argv[3] || "5", 10);
+const DELAY_MS = parseInt(process.argv[4] || "3000", 10);
+const BATCHES = parseInt(process.argv[5] || "5", 10);
+
+async function triggerCaller() {
+  const runId = `run-${Date.now()}`;
+  const url = `${BASE_URL}?id=${runId}&concurrency=${CONCURRENCY}&batches=${BATCHES}&delay=${DELAY_MS}`;
+  const start = Date.now();
+
+  try {
+    const response = await fetch(url);
+    const elapsed = Date.now() - start;
+    const body = response.status === 200 ? await response.json() : { error: await response.text() };
+
+    return {
+      status: response.status,
+      elapsed,
+      body,
+      error: null,
+    };
+  } catch (error) {
+    const elapsed = Date.now() - start;
+    return {
+      status: "ERR",
+      elapsed,
+      body: null,
+      error: error.message,
+    };
+  }
+}
+
+function printWorkerResults(report) {
+  for (const batch of report.batchResults || []) {
+    console.log(`\n${"=".repeat(70)}`);
+    console.log(`BATCH ${batch.batchId}`);
+    console.log(`${"=".repeat(70)}`);
+    console.log(`  ${"ID".padEnd(16)} ${"Status".padEnd(8)} ${"Elapsed".padEnd(10)} ${"Instance".padEnd(24)} Notes`);
+    console.log(`  ${"-".repeat(66)}`);
+
+    for (const r of batch.results || []) {
+      let notes = "";
+      if (r.status === 200 && r.elapsedMs > DELAY_MS * 2) {
+        notes = `⚠️  SLOW (+${r.elapsedMs - DELAY_MS}ms)`;
+      } else if (r.status === 429 || r.status === 503) {
+        notes = `🚫 ${r.status === 429 ? "THROTTLED" : "UNAVAILABLE"}`;
+      } else if (r.status !== 200) {
+        notes = r.error || `HTTP ${r.status}`;
+      }
+
+      console.log(
+        `  ${(r.id || "-").padEnd(16)} ${String(r.status).padEnd(8)} ${(`${r.elapsedMs}ms`).padEnd(10)} ${String(r.instanceId || "-").substring(0, 22).padEnd(24)} ${notes}`
+      );
+    }
+
+    console.log(`  ${"-".repeat(66)}`);
+    console.log(
+      `  Summary: ✅ ${batch.summary?.successCount || 0} success, 🚫 ${batch.summary?.throttledCount || 0} throttled, ❌ ${batch.summary?.errorCount || 0} errors`
+    );
+  }
+}
+
+async function main() {
+  console.log(`\nPer-Instance Concurrency Scaling Test`);
+  console.log(`=====================================`);
+  console.log(`Endpoint:        ${BASE_URL}`);
+  console.log(`Concurrency:     ${CONCURRENCY} requests per batch`);
+  console.log(`Batches:         ${BATCHES}`);
+  console.log(`Delay per req:   ${DELAY_MS}ms`);
+  console.log(`\nPlatform setting (set via Azure CLI):`);
+  console.log(`  perInstanceConcurrency: 2`);
+  console.log(`\nExpected behavior:`);
+  console.log(`  - With ${CONCURRENCY} concurrent reqs and perInstanceConcurrency=2,`);
+  console.log(`    platform should scale to ceil(${CONCURRENCY}/2) = ${Math.ceil(CONCURRENCY / 2)} instances`);
+  console.log(`  - Each instance handles max 2 requests concurrently`);
+  console.log(`  - Observe instance IDs to verify distribution`);
+
+  console.log(`\nTriggering caller function...`);
+  const runResult = await triggerCaller();
+  if (runResult.status !== 200) {
+    console.error(`❌ Caller function failed with status ${runResult.status}:`, runResult.body?.error || runResult.error);
+    process.exit(1);
+  }
+
+  const report = runResult.body;
+  printWorkerResults(report);
+
+  // Final summary
+  console.log(`\n\n${"═".repeat(70)}`);
+  console.log(`FINAL SUMMARY`);
+  console.log(`${"═".repeat(70)}`);
+
+  const totalRequests = report.summary?.totalRequests || CONCURRENCY * BATCHES;
+  const totals = report.summary || { successCount: 0, throttledCount: 0, uniqueWorkerInstances: 0 };
+
+  console.log(`Total requests sent: ${totalRequests}`);
+  console.log(`  ✅ Success:    ${totals.successCount}`);
+  console.log(`  🚫 Throttled:  ${totals.throttledCount}`);
+  console.log(`  ❌ Errors:     ${totals.errorCount || 0}`);
+  console.log(`  🧭 Caller duration: ${report.totalDurationMs}ms`);
+
+  console.log(`\nTotal unique instances observed: ${totals.uniqueWorkerInstances || 0}`);
+  console.log(`Expected instances (ceil(${CONCURRENCY}/2)): ${Math.ceil(CONCURRENCY / 2)}`);
+
+  if ((totals.uniqueWorkerInstances || 0) > 1) {
+    console.log(`\n  📊 Platform DID scale out to ${totals.uniqueWorkerInstances} instances!`);
+    console.log(`     perInstanceConcurrency is working — requests distributed across instances.`);
+  } else if ((totals.uniqueWorkerInstances || 0) === 1) {
+    console.log(`\n  ⚠️  Only 1 instance observed.`);
+    console.log(`     Possible reasons:`);
+    console.log(`     - Running locally (no platform scaling)`);
+    console.log(`     - Platform hasn't scaled yet (try more batches/longer delay)`);
+    console.log(`     - perInstanceConcurrency setting not applied`);
+  }
+
+  // Check for delays indicating queuing
+  const allResults = (report.batchResults || []).flatMap((b) => b.results || []);
+  const queuedRequests = allResults.filter(
+    (r) => r.status === 200 && r.elapsedMs > DELAY_MS * 1.8
+  );
+  if (queuedRequests.length > 0) {
+    console.log(`\n  ⏳ ${queuedRequests.length} request(s) took significantly longer than ${DELAY_MS}ms,`);
+    console.log(`     indicating they were queued before being processed.`);
+  }
+
+  console.log();
+}
+
+main().catch(console.error);

--- a/functions/flex-per-instance-concurrency/tsconfig.json
+++ b/functions/flex-per-instance-concurrency/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "sourceMap": false,
+    "module": "nodenext",
+    "target": "esnext",
+    "moduleResolution": "nodenext",
+    "noEmitOnError": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "types": ["node"],
+    "strict": true
+  },
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
This pull request introduces a new Azure Functions experiment project, `flex-concurrency-throttle`, designed to test the behavior of HTTP concurrency and throttling settings in Flex Consumption plans. The changes include all the necessary scripts, configuration, and code to build, deploy, and validate the experiment both locally and in Azure. The most important changes are grouped below:

**Deployment and Automation Scripts:**

* Added `deploy-concurrency-experiments.sh` to automate the deployment of both concurrency experiment apps, including resource creation, configuration, and publishing to Azure.
* Added `run.sh` for the `flex-concurrency-throttle` app, which builds, deploys, configures, and tests the function app in Azure, supporting environment variable overrides for flexible deployment.

**Project Setup and Configuration:**

* Added `package.json` specifying dependencies (notably Azure Functions and OpenTelemetry packages), scripts for build and start, and TypeScript configuration for the experiment app.
* Added `.funcignore` to exclude unnecessary files and folders (such as TypeScript sources, test files, and dev dependencies) from deployments, optimizing the published package.
* Added `host.json` with restrictive HTTP concurrency settings (`maxConcurrentRequests`, `maxOutstandingRequests`, `dynamicThrottlesEnabled`) to test the limits and queuing/rejection behavior in Flex Consumption.
* Added `local.settings.json` for local development, specifying encrypted runtime settings.

**Documentation and Sample Code:**

* Added a comprehensive `README.md` explaining the experiment's hypothesis, configuration, expected behavior, and instructions for local and Azure testing.
* Added a simple `http-health` function for health checks, returning instance and timestamp information.


**Useful KQL:**
```
let start = ago(10m);
requests
| where timestamp > start
| where cloud_RoleName == "azfe-concurrency-throttle"
| project
    timestamp,
    name,
    id,
    operation_Id,
    operation_ParentId,
    duration,
    cloud_RoleInstance,
    resultCode
| order by timestamp asc
```